### PR TITLE
really install in home directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,4 @@ fi
 echo "installing git-extras"
 
 cd inc/git-extras
-make install PREFIX="~/local"
-
-# for some reason a "~" folder gets created in the git-extras install
-sudo git clean -df
+make install PREFIX="$HOME/local"


### PR DESCRIPTION
Somehow replacing syntastic with ale turned into completely revamping my dot file stuff. Then I stole a lot of things from you.

The extra ~ in the git-extras repo directory was where it was actually installing the executable and man pages. Only the etc directory actually ended up under `~/local/` for some reason. I started trying to figure out why that was, but decided it was easier to just do this for now instead.