### PR TITLE
Fix #908: SSH agent forwarding from tmux

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -215,9 +215,8 @@ tmux() {
 
 add_path "$GOPATH/bin"
 
-# shellcheck disable=SC2153
-if test "$SSH_AUTH_SOCK" && test "$TMUX" && [ "$SSH_AUTH_SOCK" != "$HOME/.ssh/ssh_auth_sock" ]; then
-    export SSH_AUTH_SOCK=$SOCK
+if [ -S "$HOME/.ssh/ssh_auth_sock" ]; then
+    export SSH_AUTH_SOCK="$HOME/.ssh/ssh_auth_sock"
 fi
 
 # Unset manpath so we can inherit from /etc/manpath via the `manpath` command

--- a/ssh/rc
+++ b/ssh/rc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # https://werat.github.io/2017/02/04/tmux-ssh-agent-forwarding.html
-if [ ! -z "$SSH_CLIENT" ] && [ ! -S ~/.ssh/ssh_auth_sock ] && [ ! -z "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
-    ln -sf $SSH_AUTH_SOCK ~/.ssh/ssh_auth_sock
+if [ -n "$SSH_CLIENT" ] && [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+    ln -snf "$SSH_AUTH_SOCK" "$HOME/.ssh/ssh_auth_sock"
 fi

--- a/test/ssh-agent-forwarding.bats
+++ b/test/ssh-agent-forwarding.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+load 'helpers.bash'
+
+setup() {
+    setup_sandbox
+    SSH_RC="$SCRIPT_DIR/ssh/rc"
+    BASHRC="$SCRIPT_DIR/bashrc"
+
+    command -v python3 >/dev/null || skip "python3 required to fabricate AF_UNIX socket files"
+
+    FAKE_HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$FAKE_HOME/.ssh"
+
+    SOCK_DIR="$BATS_TEST_TMPDIR/sockets"
+    mkdir -p "$SOCK_DIR"
+}
+
+# Bind a unix-domain socket at $1. The bind survives the python exit
+# (the socket inode persists until explicit unlink), giving us a real
+# AF_UNIX socket file for the [ -S ] tests in ssh/rc.
+make_socket() {
+    python3 -c '
+import socket, sys
+s = socket.socket(socket.AF_UNIX)
+s.bind(sys.argv[1])
+' "$1"
+}
+
+@test "ssh/rc: creates symlink when SSH_CLIENT and live forwarded socket present" {
+    sock="$SOCK_DIR/agent.sock"
+    make_socket "$sock"
+
+    run env HOME="$FAKE_HOME" SSH_CLIENT="1.2.3.4 22 22" SSH_AUTH_SOCK="$sock" \
+        bash "$SSH_RC"
+    [ "$status" -eq 0 ]
+
+    [ -L "$FAKE_HOME/.ssh/ssh_auth_sock" ]
+    [ "$(readlink "$FAKE_HOME/.ssh/ssh_auth_sock")" = "$sock" ]
+}
+
+@test "ssh/rc: replaces stale symlink on re-login (regression for bug #2)" {
+    old_sock="$SOCK_DIR/old.sock"
+    new_sock="$SOCK_DIR/new.sock"
+    make_socket "$old_sock"
+    make_socket "$new_sock"
+
+    ln -s "$old_sock" "$FAKE_HOME/.ssh/ssh_auth_sock"
+
+    run env HOME="$FAKE_HOME" SSH_CLIENT="1.2.3.4 22 22" SSH_AUTH_SOCK="$new_sock" \
+        bash "$SSH_RC"
+    [ "$status" -eq 0 ]
+
+    [ "$(readlink "$FAKE_HOME/.ssh/ssh_auth_sock")" = "$new_sock" ]
+}
+
+@test "ssh/rc: no-op when SSH_CLIENT unset" {
+    sock="$SOCK_DIR/agent.sock"
+    make_socket "$sock"
+
+    run env HOME="$FAKE_HOME" SSH_CLIENT="" SSH_AUTH_SOCK="$sock" \
+        bash "$SSH_RC"
+    [ "$status" -eq 0 ]
+
+    [ ! -e "$FAKE_HOME/.ssh/ssh_auth_sock" ]
+}
+
+@test "ssh/rc: no-op when SSH_AUTH_SOCK is not a socket" {
+    not_a_sock="$SOCK_DIR/regular_file"
+    : >"$not_a_sock"
+
+    run env HOME="$FAKE_HOME" SSH_CLIENT="1.2.3.4 22 22" SSH_AUTH_SOCK="$not_a_sock" \
+        bash "$SSH_RC"
+    [ "$status" -eq 0 ]
+
+    [ ! -e "$FAKE_HOME/.ssh/ssh_auth_sock" ]
+}
+
+@test "bashrc: no \$SOCK references (regression for bug #1)" {
+    run grep -qF '$SOCK' "$BASHRC"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #908

## Summary

Three compounding bugs caused `ssh` to fail with `Permission denied (publickey)` from tmux shells on hosts that rely on a forwarded agent (no on-disk private keys):

1. `bashrc:219` referenced an undefined `$SOCK`, **silently emptying** `SSH_AUTH_SOCK`. The accompanying `# shellcheck disable=SC2153` masked the warning that would have caught the typo.
2. `ssh/rc:4` only created `~/.ssh/ssh_auth_sock` when no symlink was present, so subsequent SSH logins kept pointing at the **previous session's now-dead socket**.
3. `bashrc:219` was guarded by `$TMUX`, leaving non-tmux subprocesses (cron, editor sub-shells, Claude Code's bash) without `SSH_AUTH_SOCK` even when the symlink existed.

## Changes

- **`bashrc`** — replace the broken block with an unconditional pointer:
  ```bash
  if [ -S "$HOME/.ssh/ssh_auth_sock" ]; then
      export SSH_AUTH_SOCK="$HOME/.ssh/ssh_auth_sock"
  fi
  ```
  Drops the typo, the `$TMUX` guard, and the now-unneeded shellcheck suppression. Because `[ -S ]` follows symlinks, a stale symlink whose target no longer exists yields false — so we never clobber a working `SSH_AUTH_SOCK` (e.g. the launchd-set one on macOS-as-server) with a dead path.

- **`ssh/rc`** — drop the `! -S` guard so the symlink refreshes on every login; modernize `! -z` → `-n`; quote `$SSH_AUTH_SOCK`; use `ln -snf`:
  ```bash
  if [ -n "$SSH_CLIENT" ] && [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
      ln -snf "$SSH_AUTH_SOCK" "$HOME/.ssh/ssh_auth_sock"
  fi
  ```

- **`test/ssh-agent-forwarding.bats`** (new) — five bats tests. T2 and T5 are real regression tests that fail against the un-patched code (verified with `git stash && npm test`).

## Testing

- `npm test` → 18/18 pass with the fix
- `git stash && npm test` → tests 15 (T2: stale-symlink replacement) and 18 (T5: `$SOCK` typo guard) FAIL against the original code, confirming red-green
- `precious lint bashrc ssh/rc test/ssh-agent-forwarding.bats` → clean
- `precious tidy ...` → no changes

## Test plan

- [ ] Verify on a real host without local SSH keys: from a fresh tmux pane, `echo $SSH_AUTH_SOCK` resolves to `~/.ssh/ssh_auth_sock`, `ssh-add -l` lists the forwarded key, and `ssh some-tailnet-host` succeeds.
- [ ] Open a non-tmux subshell (e.g. `bash -l` from a cron-like context) and confirm `SSH_AUTH_SOCK` is still exported correctly.

## Caveats / known limitations (not addressed here)

- **macOS-as-server**: a stale `~/.ssh/ssh_auth_sock` symlink with a *live* target socket (e.g. left by a still-running inbound SSH session) could shadow the launchd-set agent in local terminals. The `[ -S ]` symlink-follow check prevents the dead-target case but not this narrower one.
- **ControlMaster multiplexing**: `~/.ssh/rc` is not re-executed for sessions multiplexed over an existing connection (see `ssh/config`). Pre-existing limitation, not introduced here.
- **`set -eu -o pipefail` in `ssh/rc`**: deliberately deferred — would require switching to `"${SSH_CLIENT-}"`/`"${SSH_AUTH_SOCK-}"` everywhere because `set -u` errors on unset vars. Out of scope for a bug fix; will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)