### PR TITLE
Fix #910: Add 'set -eu -o pipefail' to ssh/rc

### DIFF
--- a/ssh/rc
+++ b/ssh/rc
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -eu -o pipefail
 
 # https://werat.github.io/2017/02/04/tmux-ssh-agent-forwarding.html
-if [ -n "$SSH_CLIENT" ] && [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+if [ -n "${SSH_CLIENT-}" ] && [ -n "${SSH_AUTH_SOCK-}" ] && [ -S "${SSH_AUTH_SOCK}" ]; then
     ln -snf "$SSH_AUTH_SOCK" "$HOME/.ssh/ssh_auth_sock"
 fi

--- a/test/ssh-agent-forwarding.bats
+++ b/test/ssh-agent-forwarding.bats
@@ -65,6 +65,14 @@ s.bind(sys.argv[1])
     [ ! -e "$FAKE_HOME/.ssh/ssh_auth_sock" ]
 }
 
+@test "ssh/rc: no-op when SSH_CLIENT and SSH_AUTH_SOCK are completely unset" {
+    run env -i HOME="$FAKE_HOME" PATH="$PATH" \
+        bash "$SSH_RC"
+    [ "$status" -eq 0 ]
+
+    [ ! -e "$FAKE_HOME/.ssh/ssh_auth_sock" ]
+}
+
 @test "ssh/rc: no-op when SSH_AUTH_SOCK is not a socket" {
     not_a_sock="$SOCK_DIR/regular_file"
     : >"$not_a_sock"


### PR DESCRIPTION
Closes #910

## Changes

- `ssh/rc`: add `set -eu -o pipefail` per the CLAUDE.md convention
- `ssh/rc`: switch the `SSH_CLIENT` / `SSH_AUTH_SOCK` guards to `${VAR-}` default-empty expansion so they work under `set -u` (these variables are routinely unset in non-SSH contexts)
- `test/ssh-agent-forwarding.bats`: add a test for both variables completely unset (existing tests passed empty strings via `env VAR=`, which under `set -u` is *not* the same as unset)

## Testing

- `./node_modules/.bin/bats test/ssh-agent-forwarding.bats` — 6/6 pass
- TDD: witnessed the new test fail when `set -eu -o pipefail` was added without the `${VAR-}` change, then pass after applying it
- `precious lint -g` clean; `precious tidy -g` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)