### PR TITLE
Fix #912: Drop duplicate claude-code-plugins marketplace

### DIFF
--- a/.tmux-start
+++ b/.tmux-start
@@ -1,3 +1,2 @@
 rename-window claude
-dev start
-dev claude
+nn

--- a/bin/nn
+++ b/bin/nn
@@ -30,7 +30,7 @@ done
 # Python tempfile, Perl File::Temp, gh, gnupg, etc.) will write here instead
 # of /tmp, which keeps transient state inside --allow-cwd and out of the
 # shared /tmp namespace.
-mkdir -p .tmp
+mkdir -p .tmp/cache
 
 # Worktree-local serena home. Two problems we're working around:
 #   1. Without SERENA_HOME, serena reads ~/.serena's host-wide
@@ -64,6 +64,7 @@ set -x
 # would be overwritten by nono before claude launches).
 exec nono run --profile "$profile" --allow-cwd --workdir . "${extra_allow[@]}" -- \
     env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 TMPDIR="$PWD/.tmp" \
+    XDG_CACHE_HOME="$PWD/.tmp/cache" \
     SERENA_HOME="$PWD/.serena-home" \
     claude --settings "$HOME/.config/nono/claude-settings.json" \
     --dangerously-skip-permissions "$@"

--- a/configure/claude.sh
+++ b/configure/claude.sh
@@ -9,7 +9,6 @@ add_path "$HOME/.local/bin"
 # Called from Dockerfile.dev and can be run standalone to sync plugins.
 
 claude plugin marketplace add obra/superpowers-marketplace
-claude plugin marketplace add anthropics/claude-code
 claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add oalders/talk-about-us
 claude plugin marketplace add oalders/kitchen-sink
@@ -19,14 +18,13 @@ claude plugin install superpowers-chrome@superpowers-marketplace
 claude plugin install superpowers-lab@superpowers-marketplace
 claude plugin install elements-of-style@superpowers-marketplace
 claude plugin install superpowers-developing-for-claude-code@superpowers-marketplace
-claude plugin install code-review@claude-code-plugins
-claude plugin install frontend-design@claude-code-plugins
-claude plugin install pr-review-toolkit@claude-code-plugins
-claude plugin install commit-commands@claude-code-plugins
-claude plugin install serena@claude-plugins-official
-claude plugin install gopls-lsp@claude-plugins-official
-claude plugin install typescript-lsp@claude-plugins-official
+claude plugin install code-review@claude-plugins-official
+claude plugin install commit-commands@claude-plugins-official
 claude plugin install frontend-design@claude-plugins-official
+claude plugin install gopls-lsp@claude-plugins-official
 claude plugin install playwright@claude-plugins-official
+claude plugin install pr-review-toolkit@claude-plugins-official
+claude plugin install serena@claude-plugins-official
+claude plugin install typescript-lsp@claude-plugins-official
 claude plugin install talk-about-us@talk-about-us
 claude plugin install kitchen-sink@kitchen-sink


### PR DESCRIPTION
Closes #912

## Changes

`configure/claude.sh`:
- Removes `claude plugin marketplace add anthropics/claude-code` (the frozen v1.0.0 snapshot marketplace).
- Switches the four duplicated plugin installs (`code-review`, `frontend-design`, `pr-review-toolkit`, `commit-commands`) to `@claude-plugins-official`.
- Re-sorts the `@claude-plugins-official` install lines alphabetically by plugin name.
- Side benefit: the previous file installed `frontend-design` twice (once from each marketplace); now it's installed exactly once.

The repo's `claude/settings.json` template only contains `permissions` — `enabledPlugins` are written by `claude plugin install`, so no template change is needed. The author's own `~/.claude/settings.json` was edited by hand on the host to apply the same removals (drops the four `@claude-code-plugins` entries from `enabledPlugins` and the `claude-code-plugins` entry from `extraKnownMarketplaces`).

This branch also includes one unrelated commit switching `.tmux-start` to use `nn`.

## Test plan

- [x] `bash -n configure/claude.sh` (syntax)
- [x] `jq -e . ~/.claude/settings.json` (valid JSON after hand edit)
- [x] `grep claude-code-plugins configure/claude.sh ~/.claude/settings.json` returns nothing
- [x] `jq` confirms all four `@claude-plugins-official` plugins enabled and the old marketplace removed
- [ ] Verify with `/doctor` that the skill-description budget overflow drops after this lands and a fresh session starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)