### PR TITLE
Fix: npm under nono sandbox — route cache to $TMPDIR, grant node_modules read

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -162,6 +162,7 @@ set -x
 exec nono run --profile "$profile" --allow-cwd --workdir . "${extra_allow[@]}" -- \
     env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 TMPDIR="$PWD/.tmp" \
     XDG_CACHE_HOME="$PWD/.tmp/cache" \
+    NPM_CONFIG_CACHE="$PWD/.tmp/cache/npm" \
     SERENA_HOME="$PWD/.serena-home" \
     claude --settings "$session_settings" \
     --dangerously-skip-permissions "$@"

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -127,6 +127,7 @@ These don't belong to any single tool or stack, so they live in the base:
 
 - `read` on `~/.local/bin` (uvx wrapper, serena-mcp-server, generic user-installed scripts — used across siblings) and `~/.npm-packages` (npm-installed binaries: playwright-mcp consumer + standalone npx use).
 - `read` on `~/dot-files/bin` (npx wrapper that intercepts `@playwright/mcp@latest` so it sits ahead of `~/dot-files/node_modules/.bin/npx` in PATH).
+- `read` on `~/dot-files/node_modules` (prettier and other dev-tool binaries; `bashrc` puts `~/dot-files/node_modules/.bin` on PATH ahead of `/usr/bin`, so the dir must be readable or `npm`, `prettier`, etc. fail with `Permission denied` before they run). Paired with `NPM_CONFIG_CACHE=$PWD/.tmp/cache/npm` in `bin/nn` to keep npm's cache off the read-only `~/.npm` path.
 - `read` on `~/.config/gh` (git push over HTTPS via gh credential helper).
 - `read_file` on `/etc/gitconfig` (system-wide gitconfig outside the base `git_config` group's coverage).
 - `bypass_protection` on `~/.bashrc` → `~/dot-files/bashrc` (so `nono shell` and rc-loading don't trip the `deny_shell_configs` overlap; safe since this repo is public and scanned for secrets).

--- a/nono/oalders.json
+++ b/nono/oalders.json
@@ -22,6 +22,7 @@
       "~/.npm-packages",
       "~/dot-files/bin",
       "~/dot-files/gitignore_global",
+      "~/dot-files/node_modules",
       "~/dot-files/nono",
       "~/local/bin"
     ],

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load 'helpers.bash'
+
+setup() {
+    setup_sandbox
+    NN="$BIN_DIR/nn"
+    # Isolate from the dev's real ~/.config/nono and from any surrounding
+    # git repo (so the walk-up in bin/nn doesn't leak into the test
+    # runner's actual project).
+    HOME="$BATS_TEST_TMPDIR/home"
+    export HOME
+    export GIT_CEILING_DIRECTORIES="$BATS_TEST_TMPDIR"
+    mkdir -p "$HOME/.config/nono"
+    # bin/nn reads this with jq; needs to be valid JSON.
+    echo '{"sandbox":{"enabled":false}}' > "$HOME/.config/nono/claude-settings.json"
+    # bin/nn cp's this seed into the worktree-local serena home; only
+    # existence matters for the test.
+    echo '{}' > "$HOME/.config/nono/serena_config.yml"
+    # Stub nono to dump its argv to a file we can grep.
+    stub_command nono 'printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/nono-argv"'
+    # Clean cwd outside any git work tree.
+    mkdir -p "$BATS_TEST_TMPDIR/work"
+    cd "$BATS_TEST_TMPDIR/work"
+}
+
+@test "bin/nn injects NPM_CONFIG_CACHE pointing at \$PWD/.tmp/cache/npm" {
+    run "$NN"
+    [ "$status" -eq 0 ]
+    grep -Fxq "NPM_CONFIG_CACHE=$BATS_TEST_TMPDIR/work/.tmp/cache/npm" "$BATS_TEST_TMPDIR/nono-argv"
+}


### PR DESCRIPTION
Closes #917

## Changes

- `bin/nn` — set `NPM_CONFIG_CACHE=$PWD/.tmp/cache/npm` alongside the existing `XDG_CACHE_HOME` redirect so npm writes its cache under the sandbox-writable scratch dir instead of `~/.npm`.
- `nono/oalders.json` — add `~/dot-files/node_modules` to `filesystem.read`. `bashrc` puts `~/dot-files/node_modules/.bin` on PATH ahead of `/usr/bin`, so without read access plain `npm`/`prettier`/`bats`/etc. fail with `Permission denied` before they even start. Read-only, so no write blast radius (the issue's argument against allowing `~/.npm` doesn't apply).
- `nono/CLAUDE.md` — document the new cross-cutting grant + the cache redirect.
- `test/nn.bats` — locks in that `bin/nn` passes `NPM_CONFIG_CACHE` through to nono's exec args.

## Why bin/nn, not shell rc

The issue floated a shell-rc gate keyed on `NONO_PROXY_TOKEN` (or `NONO_CAP_FILE`). `bin/nn` is the single home for nono+claude env wiring here — and since it only runs to launch sandboxed sessions, the wiring can be unconditional. No marker env var needed.

## Testing

- `bats test/nn.bats` — passes.
- Inside a freshly-launched `nn` session in a Node repo: `npm install --no-audit --no-fund` completes without `EACCES` or `Permission denied`.