### PR TITLE
Expand CPAN allowlist in oalders-perl nono profile

### DIFF
--- a/nono/oalders-perl.json
+++ b/nono/oalders-perl.json
@@ -25,8 +25,14 @@
   },
   "network": {
     "allow_domain": [
+      "*.cpan.org",
+      "*.cpantesters.org",
       "*.metacpan.org",
-      "*.perl-magpie.org"
+      "*.perl-magpie.org",
+      "cpan.org",
+      "cpanmetadb.plackperl.org",
+      "cpantesters.org",
+      "metacpan.org"
     ]
   }
 }


### PR DESCRIPTION
Closes #918

## Changes

Adds the CPAN ecosystem hosts from #918 that weren't already covered by the existing `*.metacpan.org` / `*.perl-magpie.org` wildcards in `oalders-perl.json`:

- `*.cpan.org` + `cpan.org` (covers `www.cpan.org`, `rt.cpan.org`)
- `*.cpantesters.org` + `cpantesters.org` (covers `www.cpantesters.org`)
- `cpanmetadb.plackperl.org` — resolver fallback
- `metacpan.org` — apex to complement existing `*.metacpan.org`

Apex-+-wildcard pairing follows the convention from `oalders.json` (e.g. `*.github.com` + `github.com`).

`backpan.perl.org` intentionally omitted.

## Testing

- `jq` validates JSON syntax
- `nono profile validate ~/.config/nono/profiles/oalders-perl.json` → `Result: valid` (18 group refs OK)