### PR TITLE
Add nono profiles for snap + Hugo, with Hugo-site detection

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -63,6 +63,15 @@ if [[ -z "$profile" ]]; then
     if [[ -f "$project_root/go.mod" ]]; then
         mixins+=("oalders-go")
     fi
+    # Hugo: modern config names (hugo.toml/yaml/json) OR legacy config.toml
+    # paired with themes/ (themes/ guards against false positives on any other
+    # TOML-using project). Pulls in oalders-snap because Hugo on Linux is
+    # typically installed via snap, which needs /snap, /var/lib/snapd, and
+    # /etc/fstab readable to clear snapd's startup checks.
+    if [[ -f "$project_root/hugo.toml" || -f "$project_root/hugo.yaml" || -f "$project_root/hugo.json" ||
+        (-f "$project_root/config.toml" && -d "$project_root/themes") ]]; then
+        mixins+=("oalders-snap" "oalders-hugo")
+    fi
     if (( ${#mixins[@]} > 0 )); then
         mkdir -p "$project_root/.nono"
         extends='"oalders"'

--- a/installer/symlinks.sh
+++ b/installer/symlinks.sh
@@ -93,10 +93,12 @@ ln -sf $prefix/claude-pulse/config.json ~/.config/claude-pulse/config.json
 ln -sf $prefix/mcphub/servers.json ~/.config/mcphub/servers.json
 ln -sf $prefix/nono/oalders-chrome.json ~/.config/nono/profiles/oalders-chrome.json
 ln -sf $prefix/nono/oalders-go.json ~/.config/nono/profiles/oalders-go.json
+ln -sf $prefix/nono/oalders-hugo.json ~/.config/nono/profiles/oalders-hugo.json
 ln -sf $prefix/nono/oalders-node.json ~/.config/nono/profiles/oalders-node.json
 ln -sf $prefix/nono/oalders-perl.json ~/.config/nono/profiles/oalders-perl.json
 ln -sf $prefix/nono/oalders-playwright.json ~/.config/nono/profiles/oalders-playwright.json
 ln -sf $prefix/nono/oalders-serena.json ~/.config/nono/profiles/oalders-serena.json
+ln -sf $prefix/nono/oalders-snap.json ~/.config/nono/profiles/oalders-snap.json
 ln -sf $prefix/nono/oalders-uv.json ~/.config/nono/profiles/oalders-uv.json
 ln -sf $prefix/nono/oalders.json ~/.config/nono/profiles/oalders.json
 ln -sf $prefix/nono/claude-settings.json ~/.config/nono/claude-settings.json

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -39,6 +39,8 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 | `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), CPAN/MagPie network |
 | `oalders-node`  | `package.json`                        | `*.npmjs.org`, `registry.npmjs.org` (npm registry network access for installs)     |
 | `oalders-go`    | `go.mod`                              | Go toolchain (`go_runtime` group), build/module/lint caches (`~/.cache/go-build`, `~/.cache/golangci-lint`, `~/go/pkg/mod`), module proxy + checksum DB (`proxy.golang.org`, `sum.golang.org`), and cgo system headers (`/usr/include`, `/usr/local/include`, `/opt/homebrew/include`, pkg-config dirs, `/Library/Developer/CommandLineTools`) |
+| `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). Auto-bundled with `oalders-snap` because Hugo on Linux is typically snap-installed. |
+| `oalders-snap`  | (not standalone — pulled in by `oalders-hugo` and any future snap-backed tool) | Reads for snap-confined binaries: `/snap`, `/var/lib/snapd`, `/etc/fstab` (snapd's startup checks parse the mount table). |
 
 Example wrapper for a Node + Perl repo (`package.json` + `cpanfile` at top):
 

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -39,8 +39,8 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 | `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), CPAN/MagPie network |
 | `oalders-node`  | `package.json`                        | `*.npmjs.org`, `registry.npmjs.org` (npm registry network access for installs)     |
 | `oalders-go`    | `go.mod`                              | Go toolchain (`go_runtime` group), build/module/lint caches (`~/.cache/go-build`, `~/.cache/golangci-lint`, `~/go/pkg/mod`), module proxy + checksum DB (`proxy.golang.org`, `sum.golang.org`), and cgo system headers (`/usr/include`, `/usr/local/include`, `/opt/homebrew/include`, pkg-config dirs, `/Library/Developer/CommandLineTools`) |
-| `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). Auto-bundled with `oalders-snap` because Hugo on Linux is typically snap-installed. |
-| `oalders-snap`  | (not standalone — pulled in by `oalders-hugo` and any future snap-backed tool) | Reads for snap-confined binaries: `/snap`, `/var/lib/snapd`, `/etc/fstab` (snapd's startup checks parse the mount table). |
+| `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). When Hugo matches, `nn` also appends `oalders-snap` to the mixin list because Hugo on Linux is typically snap-installed. |
+| `oalders-snap`  | (no markers of its own — `nn` appends it alongside any snap-backed sibling like `oalders-hugo`) | Reads for snap-confined binaries: `/snap`, `/var/lib/snapd`, `/etc/fstab` (snapd's startup checks parse the mount table). |
 
 Example wrapper for a Node + Perl repo (`package.json` + `cpanfile` at top):
 

--- a/nono/oalders-hugo.json
+++ b/nono/oalders-hugo.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "oalders-hugo",
-    "description": "Hugo static site generator: cache directory. Compose with oalders-snap when Hugo is installed via snap."
+    "description": "Hugo static site generator: cache directory"
   },
   "filesystem": {
     "allow": [

--- a/nono/oalders-hugo.json
+++ b/nono/oalders-hugo.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "name": "oalders-hugo",
+    "description": "Hugo static site generator: cache directory. Compose with oalders-snap when Hugo is installed via snap."
+  },
+  "filesystem": {
+    "allow": [
+      "~/.cache/hugo_cache"
+    ]
+  }
+}

--- a/nono/oalders-snap.json
+++ b/nono/oalders-snap.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "name": "oalders-snap",
+    "description": "Reusable mixin for snap-confined binaries: reads under /snap, snapd state, and the system mount table"
+  },
+  "filesystem": {
+    "read": [
+      "/snap",
+      "/var/lib/snapd"
+    ],
+    "read_file": [
+      "/etc/fstab"
+    ]
+  }
+}


### PR DESCRIPTION
Closes #922

## Summary
- New `oalders-snap` sibling profile granting the three reads every snap-confined binary needs (`/snap`, `/var/lib/snapd`, `/etc/fstab`). Reusable by any future snap-backed tool — not Hugo-specific.
- New `oalders-hugo` sibling profile granting Hugo's cache dir (`~/.cache/hugo_cache`). Network for `hugo mod` is intentionally deferred until needed.
- Hugo-site detection in `bin/nn`: matches `hugo.toml` / `hugo.yaml` / `hugo.json` at the repo root, or `config.toml` + `themes/` for the legacy layout. When detected, `nn` appends both `oalders-snap` and `oalders-hugo` to the auto-generated wrapper's `extends` list (matches the existing Perl/Node/Go pattern).
- Detection lives in `bin/nn`, not in shell hooks — keeping nono+claude env wiring centralized there.

## Test plan
- [x] `jq` parses both new JSON files
- [x] `nono profile validate` returns "valid" for both new profiles
- [x] `shellcheck bin/nn` clean
- [x] `shfmt -d -s -i 4 bin/nn` shows no diffs for the added lines
- [x] Detection logic dry-run against 7 fixtures: 4 positive cases (each marker style) + 3 negatives (`config.toml`-only, `themes/`-only, empty repo) — all pass
- [x] Code review run + addressed (clarified composition wording in `nono/CLAUDE.md`, trimmed `oalders-hugo.json` description to match sibling style); re-review clean
- [ ] **Live smoke** in a real Hugo site: run `nn`, confirm `.nono/profile.json` contains both `oalders-snap` and `oalders-hugo`, then `hugo new posts/test.md` should succeed without `--allow` flags

## Migration note
Existing Hugo-adjacent worktrees that already have a generated `.nono/profile.json` (from a previous `nn` run) will not retroactively pick up the new mixins. One-time fix per affected worktree: `rm .nono/profile.json` and re-run `nn`. Documented at `nono/CLAUDE.md` ("Wrapper lifecycle" section).