### PR TITLE
Fix: nn Hugo stack detection misses the modular config/_default/ layout

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -63,12 +63,16 @@ if [[ -z "$profile" ]]; then
     if [[ -f "$project_root/go.mod" ]]; then
         mixins+=("oalders-go")
     fi
-    # Hugo: modern config names (hugo.toml/yaml/json) OR legacy config.toml
-    # paired with themes/ (themes/ guards against false positives on any other
-    # TOML-using project). Pulls in oalders-snap because Hugo on Linux is
-    # typically installed via snap, which needs /snap, /var/lib/snapd, and
-    # /etc/fstab readable to clear snapd's startup checks.
+    # Hugo: modern config names (hugo.toml/yaml/json), the modular
+    # config/_default/ layout, OR legacy config.toml paired with themes/.
+    # The bare hugo.* names and config/_default/ are Hugo-specific, so they
+    # need no themes/ guard; only config.toml does (it guards against false
+    # positives on any other TOML-using project). Pulls in oalders-snap
+    # because Hugo on Linux is typically installed via snap, which needs
+    # /snap, /var/lib/snapd, and /etc/fstab readable to clear snapd's
+    # startup checks.
     if [[ -f "$project_root/hugo.toml" || -f "$project_root/hugo.yaml" || -f "$project_root/hugo.json" ||
+        -d "$project_root/config/_default" ||
         (-f "$project_root/config.toml" && -d "$project_root/themes") ]]; then
         mixins+=("oalders-snap" "oalders-hugo")
     fi

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -31,6 +31,9 @@ setup() {
 }
 
 @test "bin/nn detects Hugo via the modular config/_default/ layout" {
+    # Detection keys on the config/_default/ directory existing, not on the
+    # file inside it; the hugo.toml here just mirrors a real modular-layout
+    # site so the fixture reads true to what it represents.
     mkdir -p config/_default
     echo 'baseURL = "https://example.com/"' > config/_default/hugo.toml
     run "$NN"

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -29,3 +29,21 @@ setup() {
     [ "$status" -eq 0 ]
     grep -Fxq "NPM_CONFIG_CACHE=$BATS_TEST_TMPDIR/work/.tmp/cache/npm" "$BATS_TEST_TMPDIR/nono-argv"
 }
+
+@test "bin/nn detects Hugo via the modular config/_default/ layout" {
+    mkdir -p config/_default
+    echo 'baseURL = "https://example.com/"' > config/_default/hugo.toml
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f .nono/profile.json ]
+    grep -Fq '"oalders-hugo"' .nono/profile.json
+    grep -Fq '"oalders-snap"' .nono/profile.json
+}
+
+@test "bin/nn does not detect Hugo when no config is present" {
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # No stack detected: bin/nn falls back to the bare oalders profile and
+    # writes no .nono/profile.json wrapper.
+    [ ! -f .nono/profile.json ]
+}


### PR DESCRIPTION
Closes #926

## Changes
- `bin/nn`: added a `-d "$project_root/config/_default"` check to the Hugo stack-detection condition. Hugo supports a modular config layout (`config/_default/hugo.toml`, etc.) with no root config file; detection previously failed silently for such sites. `config/_default/` is a Hugo-specific directory name, so no `themes/` guard is needed.
- Updated the comment above the detection block to document the modular layout and why it (like the bare `hugo.*` names) needs no `themes/` guard.

## Testing
- Added `test/nn.bats` coverage: a positive test for the modular layout (creates `config/_default/hugo.toml`, asserts `.nono/profile.json` contains `oalders-hugo` and `oalders-snap`) and a negative control (no config -> no wrapper written).
- Verified the positive test fails without the `bin/nn` change and passes with it.
- Full suite: all 24 bats tests pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)