### PR TITLE
Fix: merge-pr handles worktrees containing submodules

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -141,22 +141,27 @@ else
     echo "merge-pr: warning: kill-worktree-procs not found; skipping process cleanup" >&2
 fi
 
-# `git worktree remove` rejects a worktree containing submodules unless
-# --force is given TWICE; a single --force only suffices to discard
-# ordinary uncommitted changes. A clean worktree should always be
-# removable, so escalate to two --force flags when the worktree has
-# submodules. Real uncommitted work is never discarded without an
-# explicit --force from the user.
-if [[ -n "$(git -C "$worktree_path" status --porcelain)" && -z "$force" ]]; then
+# `git worktree remove` refuses a worktree that contains submodules
+# unless --force is given — even when the worktree is perfectly clean.
+# Since --force also discards uncommitted changes, first refuse a dirty
+# worktree unless the user opted in with --force. --ignore-submodules=none
+# makes the check count uncommitted work *inside* a submodule as dirty
+# even when the repo sets diff.ignoreSubmodules or a per-submodule
+# `ignore`, either of which would otherwise hide it.
+if [[ -n "$(git -C "$worktree_path" status --porcelain --ignore-submodules=none)" && -z "$force" ]]; then
     echo "" >&2
     echo "merge-pr: worktree has uncommitted changes." >&2
     echo "          Re-run with: merge-pr --force" >&2
     exit 1
 fi
 
+# Escalate to --force for a worktree with submodules (see above). A
+# single --force suffices; the .gitmodules check over-approximates (an
+# uninitialized submodule needs no --force) but forcing an
+# already-removable clean worktree is harmless.
 remove_force="$force"
 if [[ -f "$worktree_path/.gitmodules" ]]; then
-    remove_force="--force --force"
+    remove_force="--force"
 fi
 
 # shellcheck disable=SC2086
@@ -164,7 +169,8 @@ fi
 # to nothing, matching the pattern used in bin/add-worktree.
 if ! git worktree remove $remove_force "$worktree_path"; then
     echo "" >&2
-    echo "merge-pr: failed to remove worktree '$worktree_path'." >&2
+    echo "merge-pr: failed to remove worktree '$worktree_path' (see git error above)." >&2
+    echo "          To remove it manually: git worktree remove --force --force '$worktree_path'" >&2
     exit 1
 fi
 

--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -11,8 +11,8 @@ worktree, deletes the local branch, and kills the tmux session for the
 worktree. Run from inside the worktree's tmux session.
 
 Options:
-  -f, --force   Pass --force to `git worktree remove` (discards
-                uncommitted changes in the worktree).
+  -f, --force   Discard uncommitted changes in the worktree when
+                removing it.
                 May appear anywhere in the argument list.
 
 Refuses:
@@ -141,13 +141,30 @@ else
     echo "merge-pr: warning: kill-worktree-procs not found; skipping process cleanup" >&2
 fi
 
-# shellcheck disable=SC2086
-# $force is intentionally unquoted: empty string must expand to nothing,
-# matching the pattern used in bin/add-worktree.
-if ! git worktree remove $force "$worktree_path"; then
+# `git worktree remove` rejects a worktree containing submodules unless
+# --force is given TWICE; a single --force only suffices to discard
+# ordinary uncommitted changes. A clean worktree should always be
+# removable, so escalate to two --force flags when the worktree has
+# submodules. Real uncommitted work is never discarded without an
+# explicit --force from the user.
+if [[ -n "$(git -C "$worktree_path" status --porcelain)" && -z "$force" ]]; then
     echo "" >&2
     echo "merge-pr: worktree has uncommitted changes." >&2
     echo "          Re-run with: merge-pr --force" >&2
+    exit 1
+fi
+
+remove_force="$force"
+if [[ -f "$worktree_path/.gitmodules" ]]; then
+    remove_force="--force --force"
+fi
+
+# shellcheck disable=SC2086
+# $remove_force is intentionally unquoted: an empty string must expand
+# to nothing, matching the pattern used in bin/add-worktree.
+if ! git worktree remove $remove_force "$worktree_path"; then
+    echo "" >&2
+    echo "merge-pr: failed to remove worktree '$worktree_path'." >&2
     exit 1
 fi
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -53,3 +53,44 @@ setup_upstream() {
     git remote add origin "$UPSTREAM_DIR"
     git push -q -u origin HEAD
 }
+
+# Set up a feature worktree linked to the repo created by setup_git_repo +
+# setup_upstream, ready for merge-pr's cleanup path.
+# Usage: setup_feature_worktree [--with-submodule]
+# Caller must already be inside the main repo (run setup_git_repo and
+# setup_upstream first). After this:
+#   - WORKTREE_DIR holds a worktree on branch "feature" pushed to origin
+#     with no unpushed commits;
+#   - the caller's cwd is the worktree;
+#   - with --with-submodule, the worktree contains a committed submodule.
+setup_feature_worktree() {
+    local with_submodule=""
+    if [[ "${1:-}" == "--with-submodule" ]]; then
+        with_submodule="yes"
+    fi
+
+    WORKTREE_DIR="$BATS_TEST_TMPDIR/feature-wt"
+    git worktree add -q "$WORKTREE_DIR" -b feature
+    cd "$WORKTREE_DIR"
+    git config user.email "test@example.com"
+    git config user.name "Test"
+
+    if [[ -n "$with_submodule" ]]; then
+        # A submodule needs a real repo to point at. Create one and add
+        # it from inside the worktree. Local submodule adds require
+        # protocol.file.allow=always on modern git.
+        local sub_src="$BATS_TEST_TMPDIR/submodule-src"
+        mkdir -p "$sub_src"
+        git -C "$sub_src" init -q -b main
+        git -C "$sub_src" config user.email "test@example.com"
+        git -C "$sub_src" config user.name "Test"
+        echo "sub" >"$sub_src/subfile"
+        git -C "$sub_src" add subfile
+        git -C "$sub_src" -c commit.gpgsign=false commit -q -m "sub init"
+
+        git -c protocol.file.allow=always submodule add -q "$sub_src" sub
+        git -c commit.gpgsign=false commit -q -m "add submodule"
+    fi
+
+    git push -q -u origin feature
+}

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -179,6 +179,21 @@ _ready_repo() {
     [ -d "$WORKTREE_DIR" ]
 }
 
+@test "cleanup: refuses a dirty submodule despite a per-submodule ignore=all" {
+    _ready_repo
+    setup_feature_worktree --with-submodule
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+    git config submodule.sub.ignore all
+    echo "dirty" >>sub/subfile
+
+    run "$MERGE_PR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"uncommitted changes"* ]]
+    [ -d "$WORKTREE_DIR" ]
+}
+
 @test "cleanup: --force removes a worktree with a dirty submodule" {
     _ready_repo
     setup_feature_worktree --with-submodule

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -161,3 +161,33 @@ _ready_repo() {
     [[ "$output" == *"uncommitted changes"* ]]
     [ -d "$WORKTREE_DIR" ]
 }
+
+# Uncommitted work inside a submodule must count as dirty, even when the
+# repo configures diff.ignoreSubmodules to hide it from a plain status.
+@test "cleanup: refuses a dirty submodule despite diff.ignoreSubmodules=all" {
+    _ready_repo
+    setup_feature_worktree --with-submodule
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+    git config diff.ignoreSubmodules all
+    echo "dirty" >>sub/subfile
+
+    run "$MERGE_PR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"uncommitted changes"* ]]
+    [ -d "$WORKTREE_DIR" ]
+}
+
+@test "cleanup: --force removes a worktree with a dirty submodule" {
+    _ready_repo
+    setup_feature_worktree --with-submodule
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+    echo "dirty" >>sub/subfile
+
+    run "$MERGE_PR" --force
+    [ "$status" -eq 0 ]
+    [ ! -d "$WORKTREE_DIR" ]
+}

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -116,3 +116,48 @@ _ready_repo() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"refusing to act on PR in state 'DRAFT'"* ]]
 }
+
+# Cleanup path. A MERGED PR skips the actual merge and goes straight to
+# worktree removal. tmux is stubbed inert so session resolution (which
+# runs under `set -e`) doesn't abort the script.
+@test "cleanup: removes a clean worktree containing a submodule" {
+    _ready_repo
+    setup_feature_worktree --with-submodule
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+
+    run "$MERGE_PR"
+    [ "$status" -eq 0 ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
+@test "cleanup: removes a clean worktree without submodules" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+
+    run "$MERGE_PR"
+    [ "$status" -eq 0 ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
+@test "cleanup: refuses a dirty worktree without --force" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh 'printf "MERGED\tmain\n"'
+    echo "dirty" >>file
+
+    run "$MERGE_PR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"uncommitted changes"* ]]
+    [ -d "$WORKTREE_DIR" ]
+}


### PR DESCRIPTION
Closes #929

## Problem

`merge-pr` failed on worktrees containing submodules. `git worktree
remove` rejects a worktree that contains submodules unless `--force` is
passed — *even when the worktree is perfectly clean*. The script's
`--force` flag was not wired into that case, so a clean submodule
worktree could not be removed at all, and the failure was always
(wrongly) reported as "worktree has uncommitted changes".

## Changes

**`bin/merge-pr`**
- Refuses a genuinely dirty worktree (still requires explicit `--force`)
  *before* escalating, so real uncommitted work is never silently
  discarded.
- The dirty check uses `git status --porcelain --ignore-submodules=none`
  so uncommitted work *inside a submodule* still counts as dirty even
  when the repo sets `diff.ignoreSubmodules` or a per-submodule
  `ignore`, either of which would otherwise hide it.
- Escalates to a single `--force` when the worktree has a `.gitmodules`
  file, so plain `merge-pr` removes a clean submodule worktree. (A
  single `--force` is sufficient on git 2.43 — verified empirically.)
- Removal-failure message is now accurate and includes a manual
  recovery hint.

**`test/merge-pr.bats` / `test/helpers.bash`**
- Added cleanup-path coverage (none existed before): clean submodule
  worktree removed by plain `merge-pr`; clean plain worktree still
  removed; dirty worktree refused without `--force`; dirty submodule
  refused even under `diff.ignoreSubmodules=all` and under a
  per-submodule `ignore=all`; `--force` removes a dirty-submodule
  worktree. New `setup_feature_worktree` helper.

## Testing

- Full bats suite passes: 30/30.
- The core fix and the submodule-dirt hardening were each verified
  red/green: the relevant tests fail against the unfixed code and pass
  with the fix.
- `precious lint` clean on changed files.

## Review

Reviewed via `superpowers:code-reviewer` over two rounds. Round 1
flagged that `--force --force` was stronger than git requires and that
the dirty check could be blinded by `ignoreSubmodules` config; both
were addressed (single `--force`, `--ignore-submodules=none`) and a
follow-up test was added. Round 2 verdict: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)