### PR TITLE
tmux: keep only 'in progress' label in window title

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -189,19 +189,16 @@ get_github_display_name() {
     # Remove special characters that tmux doesn't like
     title=${title//[.:]/}
 
-    # Check for blocked label (prefix) and collect other labels (suffixes)
+    # blocked → 🚫 prefix; in progress → suffix. Other labels are noise in
+    # the tmux window title (and "priority: medium"-style names contain
+    # colons that tmux parses as session:window separators).
     local prefix="" suffix=""
     while IFS= read -r label; do
         [[ -z $label ]] && continue
         if [[ $label == "blocked" ]]; then
             prefix=" 🚫 "
-        else
-            # Add other labels as suffixes
-            if [[ -n $suffix ]]; then
-                suffix="$suffix [$label]"
-            else
-                suffix=" [$label]"
-            fi
+        elif [[ $label == "in progress" ]]; then
+            suffix=" [$label]"
         fi
     done <<<"$labels"
 

--- a/bin/approve-lockfile-pr.sh
+++ b/bin/approve-lockfile-pr.sh
@@ -22,7 +22,10 @@ fi
 remote="origin"
 
 gh pr view "$branch"
-gh pr checks "$branch"
+if ! gh pr checks "$branch"; then
+    read -n 1 -s -r -p "Checks failed. Press any key to continue or Ctrl-C to abort." _
+    echo
+fi
 
 # Check if main branch exists, otherwise use master
 if git show-ref --verify --quiet refs/heads/main; then


### PR DESCRIPTION
This branch contains two unrelated small fixes that were sitting on local `main`:

### `bash_functions.sh`: drop noisy labels from the tmux window title

`get_github_display_name` was appending every GitHub label as a `[name]` suffix. Labels like `priority: medium` contain a colon, which tmux parses as a `session:window` separator — `add-worktree` then failed with `can't find window` when it tried to `rename-window`.

Now only:

- `blocked` → 🚫 prefix
- `in progress` → `[in progress]` suffix

All other labels are dropped.

### `bin/approve-lockfile-pr.sh`: prompt instead of bailing on failed checks

`gh pr checks` exits nonzero when checks have failed, and `set -e` was aborting before the user could inspect the lockfile diff. Trap that case and wait for a keypress so the user can still review and decide; Ctrl-C aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)