### PR TITLE
Install Terraform on Linux dev machines + nono profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ run_mac_installers() {
 run_general_installers() {
     local installers=(
         ./installer/linux.sh
+        ./installer/terraform.sh
         ./configure/lid-poweroff.sh
         ./configure/power-profile.sh
         ./configure/touchpad-dwt.sh

--- a/installer/symlinks.sh
+++ b/installer/symlinks.sh
@@ -102,6 +102,7 @@ ln -sf $prefix/nono/oalders-perl.json ~/.config/nono/profiles/oalders-perl.json
 ln -sf $prefix/nono/oalders-playwright.json ~/.config/nono/profiles/oalders-playwright.json
 ln -sf $prefix/nono/oalders-serena.json ~/.config/nono/profiles/oalders-serena.json
 ln -sf $prefix/nono/oalders-snap.json ~/.config/nono/profiles/oalders-snap.json
+ln -sf $prefix/nono/oalders-terraform.json ~/.config/nono/profiles/oalders-terraform.json
 ln -sf $prefix/nono/oalders-uv.json ~/.config/nono/profiles/oalders-uv.json
 ln -sf $prefix/nono/oalders.json ~/.config/nono/profiles/oalders.json
 ln -sf $prefix/nono/claude-settings.json ~/.config/nono/claude-settings.json

--- a/installer/terraform.sh
+++ b/installer/terraform.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# shellcheck source=bash_functions.sh
+source ~/dot-files/bash_functions.sh
+
+# Installs the Terraform CLI from HashiCorp's official APT repo, so future
+# upgrades come along with `apt-get upgrade`. Debian/Ubuntu only.
+
+if is os name ne linux; then
+    echo "skipping. this is $(is known os name)"
+    exit 0
+fi
+
+if ! is there apt; then
+    echo "Skip terraform.sh (apt not found; only wired up for Debian/Ubuntu)"
+    exit 0
+fi
+
+if [[ $IS_SUDOER == false ]]; then
+    echo "Skip terraform.sh (Not a sudoer)"
+    exit 0
+fi
+
+keyring=/etc/apt/keyrings/hashicorp.gpg
+sources_list=/etc/apt/sources.list.d/hashicorp.list
+
+set -x
+
+if [[ ! -f $keyring ]]; then
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://apt.releases.hashicorp.com/gpg |
+        sudo gpg --dearmor -o "$keyring"
+    sudo chmod a+r "$keyring"
+fi
+
+if [[ ! -f $sources_list ]]; then
+    echo "deb [signed-by=$keyring] https://apt.releases.hashicorp.com $(lsb_release -cs) main" |
+        sudo tee "$sources_list" >/dev/null
+    sudo apt-get update -q
+fi
+
+sudo apt-get install -y -q --no-install-recommends terraform

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -48,6 +48,20 @@ Example wrapper for a Node + Perl repo (`package.json` + `cpanfile` at top):
 {"extends": ["oalders", "oalders-perl", "oalders-node"]}
 ```
 
+### Opt-in only (no auto-detection)
+
+These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in by `oalders.json` or `bin/nn` — a repo that wants them lists them in its own `.nono/profile.json`. Use when the tool's marker would produce too many false positives (e.g. `*.tf` files can show up in non-IaC repos as fixtures), or the use case is rare enough that auto-detect overhead isn't worth it.
+
+| Profile             | Owns                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
+
+Opt-in via per-repo `.nono/profile.json`:
+
+```json
+{"extends": ["oalders", "oalders-terraform"]}
+```
+
 ### Adding a new sibling
 
 1. Write `nono/oalders-<topic>.json` standalone (no `extends`).

--- a/nono/oalders-terraform.json
+++ b/nono/oalders-terraform.json
@@ -11,6 +11,7 @@
   },
   "network": {
     "allow_domain": [
+      "api.hetzner.cloud",
       "registry.terraform.io"
     ]
   }

--- a/nono/oalders-terraform.json
+++ b/nono/oalders-terraform.json
@@ -1,0 +1,17 @@
+{
+  "meta": {
+    "name": "oalders-terraform",
+    "description": "Terraform CLI: read-only user config dirs, registry network for `terraform init`"
+  },
+  "filesystem": {
+    "read": [
+      "~/.terraform.d",
+      "~/.terraformrc"
+    ]
+  },
+  "network": {
+    "allow_domain": [
+      "registry.terraform.io"
+    ]
+  }
+}

--- a/nono/oalders-terraform.json
+++ b/nono/oalders-terraform.json
@@ -12,7 +12,8 @@
   "network": {
     "allow_domain": [
       "api.hetzner.cloud",
-      "registry.terraform.io"
+      "registry.terraform.io",
+      "releases.hashicorp.com"
     ]
   }
 }


### PR DESCRIPTION
Wires Terraform into the Linux dev-machine install flow and ships an opt-in nono sibling profile so it can run sandboxed.

## What lands

- **`installer/terraform.sh`** — installs the Terraform CLI from HashiCorp's official APT repo on Debian/Ubuntu sudoers; self-skips on macOS, dnf-based distros, and non-sudoers using the same skip-line idiom as `installer/earlyoom.sh`. Keyring (`/etc/apt/keyrings/hashicorp.gpg`) and source-list creation are guarded so re-runs converge fast; `apt-get install` runs every time so subsequent `./install.sh` invocations pull upgrades.
- **`install.sh`** — `./installer/terraform.sh` added to `run_general_installers` right after `./installer/linux.sh`, so apt has been refreshed and `curl`/`gpg` are guaranteed present.
- **`nono/oalders-terraform.json`** — opt-in sibling profile:
  - `read` on `~/.terraform.d` and `~/.terraformrc`
  - `allow_domain` on `registry.terraform.io`, `releases.hashicorp.com`, `api.hetzner.cloud`
  - No `extends`; composed per-repo via `{"extends": ["oalders", "oalders-terraform"]}`
- **`installer/symlinks.sh`** — symlinks the new profile into `~/.config/nono/profiles/` between `oalders-snap` and `oalders-uv` to keep alphabetical order.
- **`nono/CLAUDE.md`** — new "Opt-in only (no auto-detection)" subsection documenting the pattern. `oalders-terraform` is its first inhabitant; the section exists so future opt-in siblings have a documented home.

## Design choices worth flagging

- **APT repo over `ubi --url`**: HashiCorp doesn't attach binaries to GitHub releases, so `ubi`'s project mode wouldn't work; the APT repo route gets free upgrades via `apt-get upgrade` and matches the apt patterns already in `linux.sh`.
- **`~/.terraform.d` is read-only**: matches the original ask. If a workflow needs the plugin cache populated under `$HOME` (rather than the project-local `.terraform/` dir, which `--allow-cwd` already covers), bump to `allow` in a follow-up.
- **No `bin/nn` auto-detection**: `*.tf` at repo root produces false positives (test fixtures, examples in non-IaC repos), so consumers opt in explicitly via per-repo `.nono/profile.json`.

## Validation

- `precious lint installer/terraform.sh` — pass (shfmt formatted).
- `bash -n installer/terraform.sh` — syntax OK.
- `nono profile validate nono/oalders-terraform.json` — `Result: valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)