### PR TITLE
Show Claude Code session ID in statusline-command.sh

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -9,6 +9,7 @@ model=$(echo "$input" | jq -r '.model.display_name // "unknown"')
 cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
 folder=$(basename "$cwd")
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+session_id=$(echo "$input" | jq -r '.session_id // empty')
 
 # ── Tokyo Night colour codes ──────────────────────────────────────────────────
 RESET="\033[0m"
@@ -31,6 +32,13 @@ folder_str=$(printf "${COMMENT}%s${RESET}" "$folder")
 
 # ── Pipe separator in comment colour ─────────────────────────────────────────
 SEP=$(printf "${COMMENT}|${RESET}")
+
+# ── Dimmed session segment (UUID truncated to 8 chars) ───────────────────────
+# Only built when session_id is present, so an absent id renders no segment.
+session_str=""
+if [ -n "$session_id" ]; then
+    session_str=$(printf "${COMMENT}session: %s${RESET}" "${session_id:0:8}")
+fi
 
 # ── Build context bar section ─────────────────────────────────────────────────
 if [ -n "$used_pct" ]; then
@@ -57,7 +65,7 @@ if [ -n "$used_pct" ]; then
     for i in $(seq 1 "$filled"); do filled_bar="${filled_bar}█"; done
 
     empty_bar=""
-    for i in $(seq 1 "$empty");  do empty_bar="${empty_bar}░"; done
+    for i in $(seq 1 "$empty"); do empty_bar="${empty_bar}░"; done
 
     bar="${COLOR}${filled_bar}${RESET}${BAR_EMPTY}${empty_bar}${RESET}"
 
@@ -67,7 +75,15 @@ if [ -n "$used_pct" ]; then
         bar_str=$(printf "%b %b${scaled}%%%b" "$bar" "$COLOR" "$RESET")
     fi
 
-    printf "%b %b %b %b %b\n" "$model_str" "$SEP" "$folder_str" "$SEP" "$bar_str"
+    if [ -n "$session_str" ]; then
+        printf "%b %b %b %b %b %b %b\n" "$model_str" "$SEP" "$folder_str" "$SEP" "$bar_str" "$SEP" "$session_str"
+    else
+        printf "%b %b %b %b %b\n" "$model_str" "$SEP" "$folder_str" "$SEP" "$bar_str"
+    fi
 else
-    printf "%b %b %b\n" "$model_str" "$SEP" "$folder_str"
+    if [ -n "$session_str" ]; then
+        printf "%b %b %b %b %b\n" "$model_str" "$SEP" "$folder_str" "$SEP" "$session_str"
+    else
+        printf "%b %b %b\n" "$model_str" "$SEP" "$folder_str"
+    fi
 fi

--- a/test/statusline-command.bats
+++ b/test/statusline-command.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load 'helpers.bash'
+
+setup() {
+    STATUSLINE="$SCRIPT_DIR/claude/statusline-command.sh"
+}
+
+# Assertions strip ANSI escape sequences (sed) so they match on visible
+# text only — the statusline emits Tokyo Night truecolor codes.
+
+@test "context-bar branch renders truncated session id" {
+    json='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/home/u/proj"},"context_window":{"used_percentage":40},"session_id":"abcd1234-5678-90ab-cdef-1234567890ab"}'
+    run bash -c "printf '%s' '$json' | '$STATUSLINE' | sed -E 's/\x1b\[[0-9;]*m//g'"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fq 'session:'
+    echo "$output" | grep -Fq 'abcd1234'
+    # Truncated: the full UUID tail must not appear.
+    ! echo "$output" | grep -Fq 'abcd1234-5678'
+}
+
+@test "no-context branch renders truncated session id" {
+    json='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/home/u/proj"},"session_id":"abcd1234-5678-90ab-cdef-1234567890ab"}'
+    run bash -c "printf '%s' '$json' | '$STATUSLINE' | sed -E 's/\x1b\[[0-9;]*m//g'"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -Fq 'session:'
+    echo "$output" | grep -Fq 'abcd1234'
+    echo "$output" | grep -Fq 'proj'
+}
+
+@test "no session segment when session_id absent (context-bar branch)" {
+    json='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/home/u/proj"},"context_window":{"used_percentage":40}}'
+    run bash -c "printf '%s' '$json' | '$STATUSLINE' | sed -E 's/\x1b\[[0-9;]*m//g'"
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -Fq 'session:'
+    # Still renders model and folder cleanly, no dangling trailing separator.
+    echo "$output" | grep -Fq 'Opus'
+    echo "$output" | grep -Fq 'proj'
+    ! echo "$output" | grep -Eq '\|[[:space:]]*$'
+}
+
+@test "no session segment when session_id absent (no-context branch)" {
+    json='{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/home/u/proj"}}'
+    run bash -c "printf '%s' '$json' | '$STATUSLINE' | sed -E 's/\x1b\[[0-9;]*m//g'"
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -Fq 'session:'
+    echo "$output" | grep -Fq 'Opus'
+    echo "$output" | grep -Fq 'proj'
+    ! echo "$output" | grep -Eq '\|[[:space:]]*$'
+}


### PR DESCRIPTION
Closes #936

## Changes

- Parse `session_id` from the Claude Code statusline JSON input alongside the existing fields (`session_id=$(echo "$input" | jq -r '.session_id // empty')`).
- Render a dimmed `session: XXXXXXXX` segment after the existing `model | folder | context-bar` layout, using the same `$COMMENT` (dim) / `$RESET` colours and `$SEP` pipe separator to match the established style.
- Session IDs are UUIDs, so the value is truncated to the first 8 chars (`${session_id:0:8}`) to keep the bar tidy.
- Added to **both** output branches (the context-bar branch and the no-context branch), guarded so an absent/empty `session_id` renders no `session:` segment and no dangling trailing separator.

## Testing

- New `test/statusline-command.bats` (bats) covering both branches, with and without `session_id`:
  - context-bar branch renders the truncated id and the word `session:`
  - no-context branch renders the truncated id
  - absent `session_id` renders no `session:` segment and no trailing separator (both branches)
- TDD red-green verified: the two "renders session id" tests fail with the fix reverted and pass with it in place.
- Full suite run via `npm test`: 32/34 pass. The 2 failures are pre-existing, environment-specific (`AF_UNIX path too long`) failures in `test/ssh-agent-forwarding.bats`, unrelated to this change and present on the base commit.
- `shfmt -d -s -i 4 claude/statusline-command.sh` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)