### PR TITLE
Fix: merge-pr misdiagnoses misconfigured tracking as a missing push

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -59,9 +59,40 @@ if [[ "$branch" == "HEAD" ]]; then
 fi
 
 # Pre-flight: branch must have an upstream.
+#
+# `@{u}` fails both when the branch is genuinely unpushed AND when it is
+# already on origin but its local tracking config is wrong (e.g.
+# branch.<name>.remote points at a clone URL instead of "origin"). In the
+# latter case "push first" misdiagnoses the problem — the branch is pushed;
+# only the tracking config needs repair. Distinguish the two by asking
+# origin directly.
 if ! git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    echo "merge-pr: branch '$branch' has no upstream — push first" >&2
-    exit 1
+    # Query the full ref path, not a bare name: `ls-remote origin foo`
+    # tail-matches path components and would also match `refs/heads/x/foo`,
+    # false-flagging a genuinely unpushed branch. The output is a single
+    # line, so `grep -q` consuming it before ls-remote blocks keeps the
+    # pipe safe under pipefail — don't widen this query.
+    if git ls-remote origin "refs/heads/$branch" 2>/dev/null | grep -q .; then
+        echo "merge-pr: branch '$branch' is on origin, but local tracking config" >&2
+        echo "          is wrong, so '@{u}' does not resolve. The branch is" >&2
+        echo "          already pushed — this is a config issue, not a missing push." >&2
+        printf "merge-pr: repair with 'git branch --set-upstream-to=origin/%s' and continue? [y/N] " "$branch" >&2
+        # Default to bailing: empty input (just Enter), EOF, or a
+        # non-interactive stdin all leave tracking untouched.
+        read -r reply || reply=""
+        case "$reply" in
+            [Yy]*)
+                git branch --set-upstream-to="origin/$branch" >&2
+                ;;
+            *)
+                echo "merge-pr: aborted — fix tracking config and re-run." >&2
+                exit 1
+                ;;
+        esac
+    else
+        echo "merge-pr: branch '$branch' has no upstream — push first" >&2
+        exit 1
+    fi
 fi
 
 # Pre-flight: no unpushed commits.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -54,6 +54,18 @@ setup_upstream() {
     git push -q -u origin HEAD
 }
 
+# Break the current branch's tracking config so `@{u}` no longer resolves,
+# while the branch remains pushed to origin. Simulates the bug in #935:
+# branch.<name>.remote set to a clone URL instead of "origin". Caller must
+# already be inside a repo with the branch pushed (run setup_git_repo and
+# setup_upstream first).
+break_tracking_config() {
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    git config "branch.$branch.remote" "$UPSTREAM_DIR"
+    git config "branch.$branch.merge" "refs/heads/$branch"
+}
+
 # Set up a feature worktree linked to the repo created by setup_git_repo +
 # setup_upstream, ready for merge-pr's cleanup path.
 # Usage: setup_feature_worktree [--with-submodule]

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -57,6 +57,63 @@ setup() {
     [[ "$output" == *"has no upstream"* ]]
 }
 
+# #935: when @{u} fails but the branch IS on origin (only the local
+# tracking config is wrong), don't misdiagnose it as "push first".
+@test "pre-flight: misconfigured tracking is not reported as 'push first'" {
+    setup_git_repo
+    setup_upstream
+    break_tracking_config
+    run "$MERGE_PR" </dev/null
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"push first"* ]]
+    [[ "$output" == *"is on origin"* ]]
+    [[ "$output" == *"--set-upstream-to=origin/main"* ]]
+}
+
+# Declining the repair prompt (empty input / no) leaves tracking untouched.
+@test "pre-flight: declining the tracking-repair prompt aborts without changes" {
+    setup_git_repo
+    setup_upstream
+    break_tracking_config
+    run "$MERGE_PR" <<<"n"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"aborted"* ]]
+    run git config "branch.main.remote"
+    [[ "$output" == "$UPSTREAM_DIR" ]]
+}
+
+# Accepting the repair prompt rewrites tracking to origin and proceeds past
+# the upstream pre-flight (then fails later at PR lookup — far enough to
+# prove the repair worked).
+@test "pre-flight: accepting the tracking-repair prompt sets upstream to origin" {
+    setup_git_repo
+    setup_upstream
+    break_tracking_config
+    stub_command gh 'exit 1'
+    run "$MERGE_PR" <<<"y"
+    # Repair succeeded, so the upstream pre-flight passed and we reached
+    # PR lookup (which the gh stub fails).
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no PR found"* ]]
+    run git config "branch.main.remote"
+    [[ "$output" == "origin" ]]
+}
+
+# A genuinely unpushed branch whose name is a path suffix of an existing
+# remote branch (e.g. local "foo" vs remote "feature/foo") must still get
+# "push first", not the repair prompt. Guards against ls-remote tail-match.
+@test "pre-flight: unpushed branch sharing a suffix with a remote branch says 'push first'" {
+    setup_git_repo
+    setup_upstream
+    git checkout -q -b feature/foo
+    git push -q -u origin feature/foo
+    git checkout -q -b foo main
+    run "$MERGE_PR" </dev/null
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"push first"* ]]
+    [[ "$output" != *"is on origin"* ]]
+}
+
 @test "pre-flight: refuses when branch has unpushed commits" {
     setup_git_repo
     setup_upstream


### PR DESCRIPTION
Closes #935

## Problem
`merge-pr`'s pre-flight reported `branch '<name>' has no upstream — push first` whenever `@{u}` failed to resolve. But `@{u}` also fails when the branch **is** already on origin and only the local tracking config is wrong (e.g. `branch.<name>.remote` set to a clone URL instead of `origin`). In that case `git push` says "Everything up-to-date" and the error persists — the advice never fixes the problem.

## Changes
- `bin/merge-pr`: when `@{u}` fails, query origin for the exact ref (`git ls-remote origin "refs/heads/$branch"`).
  - **Branch on origin** → it's a tracking-config issue. Prompt to repair with `git branch --set-upstream-to=origin/$branch`, **defaulting to bail** (empty input, EOF, or non-interactive stdin all leave config untouched), then continue the merge if accepted.
  - **Branch not on origin** → keep the existing `push first` message.
- Use the full `refs/heads/$branch` ref (not a bare name) so a path-suffix sibling like remote `feature/foo` can't false-match a local unpushed `foo`.
- `test/helpers.bash`: `break_tracking_config` helper reproducing the #935 condition.
- `test/merge-pr.bats`: 4 new tests (misdiagnosis fixed, decline leaves config untouched, accept repairs + proceeds, tail-match regression).

## Testing
- 23/23 `merge-pr` bats tests pass; `shellcheck` and `precious lint` clean.
- The 2 failing `ssh-agent-forwarding` tests are a pre-existing environment artifact (`AF_UNIX path too long`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)