### PR TITLE
Fix: merge-pr should bail out before merge if there are uncommitted changes

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -19,6 +19,8 @@ Refuses:
   --auto, --auto-merge   gh pr merge would exit 0 while the PR stays
                          OPEN, and our cleanup would tear down the
                          worktree before the merge actually happens.
+  dirty worktree         Bails before merging when there are uncommitted
+                         changes, unless --force is given.
 EOF
 }
 
@@ -102,6 +104,20 @@ if [[ "$unpushed" -ne 0 ]]; then
     exit 1
 fi
 
+# Pre-flight: refuse a dirty worktree *before* merging. This runs up front
+# (before `gh pr merge`) so we never merge a PR and then strand the user
+# with uncommitted work we can't safely clean up. --force is the opt-in to
+# discard those changes during cleanup, so it suppresses this bail.
+# cwd is the worktree here (the script is run from inside it), so a plain
+# `git status` suffices. --ignore-submodules=none counts uncommitted work
+# *inside* a submodule as dirty even when the repo sets diff.ignoreSubmodules
+# or a per-submodule `ignore`, either of which would otherwise hide it.
+if [[ -z "$force" && -n "$(git status --porcelain --ignore-submodules=none)" ]]; then
+    echo "merge-pr: worktree has uncommitted changes — commit or stash first," >&2
+    echo "          or re-run with: merge-pr --force" >&2
+    exit 1
+fi
+
 # State capture (before any mutation).
 worktree_path=$(git rev-parse --show-toplevel)
 git_common_dir=$(git rev-parse --git-common-dir)
@@ -174,18 +190,9 @@ fi
 
 # `git worktree remove` refuses a worktree that contains submodules
 # unless --force is given — even when the worktree is perfectly clean.
-# Since --force also discards uncommitted changes, first refuse a dirty
-# worktree unless the user opted in with --force. --ignore-submodules=none
-# makes the check count uncommitted work *inside* a submodule as dirty
-# even when the repo sets diff.ignoreSubmodules or a per-submodule
-# `ignore`, either of which would otherwise hide it.
-if [[ -n "$(git -C "$worktree_path" status --porcelain --ignore-submodules=none)" && -z "$force" ]]; then
-    echo "" >&2
-    echo "merge-pr: worktree has uncommitted changes." >&2
-    echo "          Re-run with: merge-pr --force" >&2
-    exit 1
-fi
-
+# A dirty tree was already refused up front (unless --force), so by here
+# the worktree is clean or the user opted in to discarding changes.
+#
 # Escalate to --force for a worktree with submodules (see above). A
 # single --force suffices; the .gitmodules check over-approximates (an
 # uninitialized submodule needs no --force) but forcing an

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -251,6 +251,48 @@ _ready_repo() {
     [ -d "$WORKTREE_DIR" ]
 }
 
+# #940: a dirty worktree must bail *before* the merge runs, not after.
+# The gh stub distinguishes `pr view` (state lookup) from `pr merge`
+# (the actual merge), recording a marker file iff merge was invoked.
+@test "pre-flight: dirty worktree bails before merging an OPEN PR" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+    echo "dirty" >>file
+
+    run "$MERGE_PR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"uncommitted changes"* ]]
+    [ ! -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    [ -d "$WORKTREE_DIR" ]
+}
+
+@test "pre-flight: --force merges and cleans up a dirty worktree" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+    echo "dirty" >>file
+
+    run "$MERGE_PR" --force
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+}
+
 @test "cleanup: --force removes a worktree with a dirty submodule" {
     _ready_repo
     setup_feature_worktree --with-submodule

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -205,7 +205,7 @@ _ready_repo() {
     [ -z "$output" ]
 }
 
-@test "cleanup: refuses a dirty worktree without --force" {
+@test "pre-flight: refuses a dirty worktree without --force" {
     _ready_repo
     setup_feature_worktree
     unset TMUX
@@ -221,7 +221,7 @@ _ready_repo() {
 
 # Uncommitted work inside a submodule must count as dirty, even when the
 # repo configures diff.ignoreSubmodules to hide it from a plain status.
-@test "cleanup: refuses a dirty submodule despite diff.ignoreSubmodules=all" {
+@test "pre-flight: refuses a dirty submodule despite diff.ignoreSubmodules=all" {
     _ready_repo
     setup_feature_worktree --with-submodule
     unset TMUX
@@ -236,7 +236,7 @@ _ready_repo() {
     [ -d "$WORKTREE_DIR" ]
 }
 
-@test "cleanup: refuses a dirty submodule despite a per-submodule ignore=all" {
+@test "pre-flight: refuses a dirty submodule despite a per-submodule ignore=all" {
     _ready_repo
     setup_feature_worktree --with-submodule
     unset TMUX


### PR DESCRIPTION
Closes #940

## Changes
- Added an up-front pre-flight in `bin/merge-pr` (right after the "no unpushed commits" check, before state capture) that refuses a dirty worktree *before* `gh pr merge` runs. Previously the only uncommitted-changes guard lived in the cleanup phase, which executed *after* the merge — so a dirty tree would merge the PR and then fail cleanup, stranding the user.
- `--force` remains the opt-in to discard uncommitted changes during cleanup, so it suppresses the bail.
- Kept `--ignore-submodules=none` so uncommitted work inside a submodule still counts as dirty even under `diff.ignoreSubmodules` or a per-submodule `ignore`.
- Removed the now-redundant dirty-refusal block from the cleanup phase; kept the submodule `--force` escalation. Updated comments and the `usage()` "Refuses:" section.

## Testing
- `bats test/merge-pr.bats` — all 25 tests pass.
- Added two tests using a `gh` stub that distinguishes `pr view` from `pr merge` via a marker file:
  - dirty OPEN PR without `--force` → exit 1, "uncommitted changes", merge never invoked, worktree intact.
  - dirty OPEN PR with `--force` → exit 0, merge invoked, worktree removed.
- Red-green verified: disabling the new guard makes the bail test (and the existing MERGED-state dirty tests) fail; restoring it makes all green.
- `precious lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)