### PR TITLE
Add `nn --clodhopper` flag to init clodhopper in local Claude settings

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -5,13 +5,17 @@ set -eu -o pipefail
 # Parse nn-specific flags out of $@ before forwarding the rest to claude.
 # --chrome enables the superpowers-chrome MCP for this session only.
 # --playwright force-enables the playwright MCP regardless of e2e/ markers.
+# --clodhopper wires clodhopper's hooks into .claude/settings.local.json
+# (gitignored) for this session, so shared project repos stay clean.
 chrome_enabled=0
 playwright_forced=0
+clodhopper_enabled=0
 forwarded_args=()
 for arg in "$@"; do
     case "$arg" in
         --chrome) chrome_enabled=1 ;;
         --playwright) playwright_forced=1 ;;
+        --clodhopper) clodhopper_enabled=1 ;;
         *) forwarded_args+=("$arg") ;;
     esac
 done
@@ -169,6 +173,19 @@ fi
 
 echo "🗯️nn: using profile $profile_label" >&2
 echo "🗯️nn: using settings $settings_label" >&2
+
+# Opt-in clodhopper wiring. clodhopper init --local writes the hooks into
+# .claude/settings.local.json (gitignored). --settings adds a settings source;
+# it doesn't replace the project hierarchy, so claude still loads
+# settings.local.json alongside it. Runs outside the sandbox, same as the rest
+# of this setup, so it can write under cwd freely. Failing here aborts the
+# launch (set -e) by design: --clodhopper is an explicit opt-in for session
+# observability, so a wiring failure should surface, not silently launch
+# unwired.
+if ((clodhopper_enabled)); then
+    echo "🗯️nn: wiring clodhopper into .claude/settings.local.json" >&2
+    clodhopper init --local
+fi
 
 set -x
 # nono's allow_domain entries are injected into NO_PROXY inside the sandbox,

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -50,3 +50,38 @@ setup() {
     # writes no .nono/profile.json wrapper.
     [ ! -f .nono/profile.json ]
 }
+
+@test "bin/nn --clodhopper runs clodhopper init --local" {
+    # Stub clodhopper to record its argv so we can assert how it was invoked.
+    stub_command clodhopper 'printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/clodhopper-argv"'
+    run "$NN" --clodhopper
+    [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/clodhopper-argv" ]
+    grep -Fxq -- "init" "$BATS_TEST_TMPDIR/clodhopper-argv"
+    grep -Fxq -- "--local" "$BATS_TEST_TMPDIR/clodhopper-argv"
+}
+
+@test "bin/nn --clodhopper is consumed, not forwarded to claude" {
+    stub_command clodhopper 'true'
+    run "$NN" --clodhopper
+    [ "$status" -eq 0 ]
+    # The nn-specific flag must be parsed out of $@, not passed through to claude.
+    ! grep -Fxq -- "--clodhopper" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn --clodhopper is parsed out independently of forwarded args" {
+    stub_command clodhopper 'true'
+    run "$NN" --clodhopper --resume
+    [ "$status" -eq 0 ]
+    # The nn-specific flag is consumed; the unrelated arg still reaches claude.
+    ! grep -Fxq -- "--clodhopper" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "--resume" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn does not run clodhopper without the flag" {
+    # If clodhopper were invoked, this stub would fail the test by exiting 1.
+    stub_command clodhopper 'echo "clodhopper should not run" >&2; exit 1'
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ ! -f "$BATS_TEST_TMPDIR/clodhopper-argv" ]
+}


### PR DESCRIPTION
Closes #944

## Changes
- Add a `--clodhopper` flag to `bin/nn`. When passed, `nn` runs `clodhopper init --local` before launching `claude`, wiring clodhopper's hooks into `.claude/settings.local.json` (gitignored) for the session.
- The flag is parsed out of `$@` in the same loop as the existing `--chrome` / `--playwright` nn-specific flags, so it is consumed by `nn` and **not** forwarded to `claude`.
- Wiring is opt-in (no-op when the flag is absent) and prints a `🗯️nn:` status line, consistent with the existing profile/settings status lines.
- Scope is `--local` only (per the issue's decided open questions); no `--clodhopper-project` variant.

### Design note
Failing under `set -e` if `clodhopper init --local` fails is intentional: `--clodhopper` is an explicit opt-in for session observability, so a wiring failure should surface rather than silently launching an unwired session. `clodhopper` prints its own diagnostic on failure.

## Testing
- Added 4 bats tests to `test/nn.bats`:
  - `--clodhopper` runs `clodhopper init --local`
  - `--clodhopper` is consumed, not forwarded to claude
  - `--clodhopper` is parsed out independently of forwarded args (e.g. `--resume` still reaches claude)
  - no clodhopper invocation without the flag
- All `bin/nn` bats tests pass (`bats test/nn.bats` → 7/7).
- `precious lint bin/nn test/nn.bats` clean.

## Review
Reviewed via `superpowers:code-reviewer` (two rounds): verdict "Ready to merge: Yes", no Critical/Important issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)