### PR TITLE
Fix: bind test sockets via relative path to stay under sun_path limit

### DIFF
--- a/test/ssh-agent-forwarding.bats
+++ b/test/ssh-agent-forwarding.bats
@@ -21,12 +21,13 @@ setup() {
 # AF_UNIX socket file for the [ -S ] tests in ssh/rc.
 #
 # Bind via a path relative to the socket's directory: the string passed to
-# bind() must fit in struct sockaddr_un.sun_path (108 bytes on Linux), and
-# $BATS_TEST_TMPDIR nests under $TMPDIR, which the nono sandbox points at a
-# deep worktree path that overflows the limit (issue #946). chdir-ing first
-# keeps the bound name short ("agent.sock") while the socket file still lands
-# at the intended absolute path. The [ -S ] / readlink checks in ssh/rc stat
-# that absolute path (no length limit) rather than connect(), so this is safe.
+# bind() must fit in struct sockaddr_un.sun_path (108 bytes on Linux, 104 on
+# macOS), and $BATS_TEST_TMPDIR nests under $TMPDIR, which the nono sandbox
+# points at a deep worktree path that overflows the limit (issue #946).
+# chdir-ing first keeps the bound name short ("agent.sock") while the socket
+# file still lands at the intended absolute path. The [ -S ] / readlink checks
+# in ssh/rc stat that absolute path (no length limit) rather than connect(),
+# so this is safe.
 make_socket() {
     python3 -c '
 import os, socket, sys

--- a/test/ssh-agent-forwarding.bats
+++ b/test/ssh-agent-forwarding.bats
@@ -19,11 +19,22 @@ setup() {
 # Bind a unix-domain socket at $1. The bind survives the python exit
 # (the socket inode persists until explicit unlink), giving us a real
 # AF_UNIX socket file for the [ -S ] tests in ssh/rc.
+#
+# Bind via a path relative to the socket's directory: the string passed to
+# bind() must fit in struct sockaddr_un.sun_path (108 bytes on Linux), and
+# $BATS_TEST_TMPDIR nests under $TMPDIR, which the nono sandbox points at a
+# deep worktree path that overflows the limit (issue #946). chdir-ing first
+# keeps the bound name short ("agent.sock") while the socket file still lands
+# at the intended absolute path. The [ -S ] / readlink checks in ssh/rc stat
+# that absolute path (no length limit) rather than connect(), so this is safe.
 make_socket() {
     python3 -c '
-import socket, sys
+import os, socket, sys
+directory, name = os.path.split(sys.argv[1])
+if directory:
+    os.chdir(directory)
 s = socket.socket(socket.AF_UNIX)
-s.bind(sys.argv[1])
+s.bind(name)
 ' "$1"
 }
 


### PR DESCRIPTION
Closes #946

## Problem

`make_socket()` in `test/ssh-agent-forwarding.bats` fabricated an AF_UNIX socket by binding the **full absolute path** under `$BATS_TEST_TMPDIR`. That directory nests under `$TMPDIR`, which the nono sandbox points at a deep worktree-local path (e.g. `/home/olaf/.worktree/dot-files/.../.tmp/claude-1000/...`). The bound path then exceeded the Linux `struct sockaddr_un.sun_path` limit (108 bytes; 104 on macOS), so `socket.bind()` raised `OSError: AF_UNIX path too long` and tests 35 & 37 failed.

It only reproduced in deep-path environments (worktrees + sandbox `TMPDIR`), so it passed from a short checkout like `~/dot-files` and slipped past CI while breaking local sandboxed runs.

## Fix

`chdir` into the socket's directory in the python helper and `bind()` the **relative basename** (`agent.sock`, ~10 bytes). The socket file still lands at the intended absolute path; only the string passed to `bind()` is shortened.

This is safe because `ssh/rc` only `stat`s/`readlink`s the path (`[ -S ]`, `readlink`) and never `connect()`s — the `sun_path` limit applies to bind/connect addresses, not to filesystem `stat()`. Coverage is fully preserved (no skips), and there's no dependency on a writable `/tmp` (the sandbox denies directory removal there, which is why `bin/nn` uses a worktree-local `TMPDIR` in the first place).

## Testing

- Full bats suite under the real deep `$TMPDIR`: `1..40`, **40 passing, 0 failing** (exit 0).
- Red-green confirmed: the old absolute-bind fails with `AF_UNIX path too long` on a 188-byte path; the new relative-bind succeeds and the socket exists at the absolute path.
- `precious lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)