### PR TITLE
Fix: load global CLAUDE.md in nono sandbox (#948)

### DIFF
--- a/bin/test-nono-claude-md.sh
+++ b/bin/test-nono-claude-md.sh
@@ -18,12 +18,17 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 profile="$repo_root/nono/oalders.json"
 path="$HOME/.claude/CLAUDE.md"
 
-verdict=$(nono why --path "$path" --op read --profile "$profile" 2>&1 | head -1)
+# Capture once (stdout+stderr) so the failure path can echo the full output
+# without a second invocation. nono why exits 0 for both ALLOWED and DENIED,
+# so the verdict is read from the output: grab the first ALLOWED/DENIED line
+# rather than head -1, so a stray stderr warning can't masquerade as it.
+output=$(nono why --path "$path" --op read --profile "$profile" 2>&1)
+verdict=$(printf '%s\n' "$output" | grep -m1 -E '^(ALLOWED|DENIED)' || true)
 
 if [[ $verdict == ALLOWED* ]]; then
     echo "ok: $profile grants read on $path"
 else
     echo "FAIL: $profile does not grant read on $path" >&2
-    nono why --path "$path" --op read --profile "$profile" >&2
+    printf '%s\n' "$output" >&2
     exit 1
 fi

--- a/bin/test-nono-claude-md.sh
+++ b/bin/test-nono-claude-md.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Regression test for issue #948: the global Claude Code instructions
+# (~/.claude/CLAUDE.md, a symlink to ~/dot-files/claude/CLAUDE.md) must be
+# readable inside the oalders sandbox, or none of the global instructions
+# reach the model in sandboxed sessions.
+#
+# Uses `nono why` rather than a full `nono run` so it validates the policy
+# grant without needing to spin up the proxy/supervisor — runnable even from
+# inside an existing sandbox.
+
+set -eu -o pipefail
+
+# Test the repo's own profile (resolved relative to this script) rather than
+# the installed `oalders` symlink, so the test validates the source of truth
+# and runs correctly from a worktree before the change is merged/symlinked.
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+profile="$repo_root/nono/oalders.json"
+path="$HOME/.claude/CLAUDE.md"
+
+verdict=$(nono why --path "$path" --op read --profile "$profile" 2>&1 | head -1)
+
+if [[ $verdict == ALLOWED* ]]; then
+    echo "ok: $profile grants read on $path"
+else
+    echo "FAIL: $profile does not grant read on $path" >&2
+    nono why --path "$path" --op read --profile "$profile" >&2
+    exit 1
+fi

--- a/gitignore_global
+++ b/gitignore_global
@@ -54,3 +54,5 @@ node_modules/
 ########################################
 .serena-home/
 .tmp/
+
+**/.claude/settings.local.json

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -146,6 +146,7 @@ These don't belong to any single tool or stack, so they live in the base:
 - `read` on `~/dot-files/node_modules` (prettier and other dev-tool binaries; `bashrc` puts `~/dot-files/node_modules/.bin` on PATH ahead of `/usr/bin`, so the dir must be readable or `npm`, `prettier`, etc. fail with `Permission denied` before they run). Paired with `NPM_CONFIG_CACHE=$PWD/.tmp/cache/npm` in `bin/nn` to keep npm's cache off the read-only `~/.npm` path.
 - `read` on `~/.config/gh` (git push over HTTPS via gh credential helper).
 - `read_file` on `/etc/gitconfig` (system-wide gitconfig outside the base `git_config` group's coverage).
+- `read_file` on `~/dot-files/claude/CLAUDE.md` (the global Claude Code instructions). `~/.claude/CLAUDE.md` is a symlink to this path; without the grant the harness can't follow the symlink and none of the global instructions load in sandboxed sessions. Single-file grant rather than a `read` on `~/dot-files/claude/` — `statusline-command.sh` is the only other file under there the sandbox needs, and it's already granted below.
 - `read_file` on `~/dot-files/claude/statusline-command.sh` (the Claude Code statusline script, run sandboxed as a child of claude; `bin/nn` injects the matching `statusLine` block into the session settings since the sandbox can't read `~/.claude/settings.json`).
 - `bypass_protection` on `~/.bashrc` → `~/dot-files/bashrc` (so `nono shell` and rc-loading don't trip the `deny_shell_configs` overlap; safe since this repo is public and scanned for secrets).
 

--- a/nono/oalders.json
+++ b/nono/oalders.json
@@ -35,6 +35,7 @@
       "~/.docker/config.json",
       "~/.gitconfig",
       "~/dot-files/bashrc",
+      "~/dot-files/claude/CLAUDE.md",
       "~/dot-files/claude/statusline-command.sh"
     ],
     "allow_file": [


### PR DESCRIPTION
Closes #948

## Part 1 — global CLAUDE.md not loaded (fixed)

`~/.claude/CLAUDE.md` is a symlink to `~/dot-files/claude/CLAUDE.md`, and no nono
capability covered that resolved path — so the global Claude Code instructions
never loaded in sandboxed sessions.

- Add `~/dot-files/claude/CLAUDE.md` to `nono/oalders.json`'s `filesystem.read_file`
  (single-file grant, matching the existing `statusline-command.sh` entry and the
  repo's "prefer specific subpaths" convention).
- Document it in `nono/CLAUDE.md`.

## Part 2 — `$TMPDIR` write-only (does not reproduce; no change)

Investigated and could **not** reproduce on the current setup. `bin/nn` already sets
`TMPDIR=$PWD/.tmp` and launches with `--allow-cwd`, which makes `$TMPDIR` read+write.
The original report's `nono why` was run without `--allow-cwd`, which only reflects
the base profile (write-only), not runtime.

Verified two ways:
- Live in-sandbox write-then-read of `$TMPDIR/x` — succeeds.
- `nono why --path "$PWD/.tmp/x" --op read --profile oalders --allow "$PWD"` → `ALLOWED` (read+write).

The worktree-local `TMPDIR` change (commit `5358237`, 2026-04-29) already resolved this.
A residual gap remains for tools that hardcode `/tmp` instead of honoring `$TMPDIR` —
left for a follow-up if/when a concrete case surfaces, consistent with the existing
per-tool `/tmp/claude-1000` grant.

## Testing

- New `bin/test-nono-claude-md.sh`: asserts the grant via `nono why` against the
  repo's own profile (so it runs from a worktree pre-merge). Verified red→green —
  fails (exit 1) without the grant, passes with it.
- `nono policy validate` clean; `shfmt -s` and `shellcheck` clean on the test.
- Reviewed via `superpowers:code-reviewer` (two rounds); verdict "Ready to merge".

🤖 Generated with [Claude Code](https://claude.com/claude-code)