### PR TITLE
Fix: auto-run /kitchen-sink:fix-gh-issue on first nn launch for fix-<n> worktrees

### DIFF
--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -2,9 +2,9 @@
 
 set -e -u -o pipefail
 
-force=""
+force=()
 if [[ "${1:-}" == "-f" ]]; then
-    force="-f"
+    force=(-f)
     shift
 fi
 
@@ -54,9 +54,9 @@ worktree_dir="$all_worktrees/$branch_name"
 
 if [[ "$type" == "pr" ]]; then
     # For PR checkouts, create worktree without -b flag (gh pr checkout will create the branch)
-    git worktree add $force "$worktree_dir"
+    git worktree add "${force[@]+"${force[@]}"}" "$worktree_dir"
 else
-    git worktree add $force "$worktree_dir" -b "$branch_name"
+    git worktree add "${force[@]+"${force[@]}"}" "$worktree_dir" -b "$branch_name"
 fi
 
 cd "$worktree_dir" || exit 1

--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -61,9 +61,18 @@ fi
 
 cd "$worktree_dir" || exit 1
 
-# Handle GitHub PRs
+# Handle GitHub PRs and issues
 if [[ "$type" == "pr" ]]; then
     gh pr checkout "$number"
+elif [[ "$type" == "issue" ]]; then
+    # Queue the first `nn` launch in this worktree to auto-run
+    # `/kitchen-sink:fix-gh-issue` (it infers issue #$number from the
+    # fix-<n> branch name). bin/nn reads this marker, hands the line to
+    # claude as its initial prompt, then deletes it — so the command fires
+    # exactly once and never re-triggers across tmux/nono sessions. Lives
+    # under .tmp/ (gitignored, worktree-local scratch).
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
 fi
 
 # `submodule.alternateLocation=superproject` is supposed to share objects with

--- a/bin/nn
+++ b/bin/nn
@@ -198,14 +198,20 @@ fi
 auto_prompt=()
 fix_marker="$PWD/.tmp/fix-gh-issue.pending"
 if [[ -f $fix_marker ]]; then
+    # Only the first line of the marker is read; the marker is always a
+    # single hardcoded slash command today, so multi-line content is not
+    # expected. `|| true` keeps `set -e` from aborting on an empty marker
+    # (read returns non-zero at EOF before a newline).
     read -r pending_prompt <"$fix_marker" || true
     rm -f "$fix_marker"
     # Treat the first non-flag positional as a user-supplied prompt and
     # suppress the queued one. The heuristic is intentionally simple: any
     # arg starting with `-` is assumed to be a flag, so flag-only first
     # launches (e.g. `nn --resume`) still get the queued prompt injected,
-    # which is the desired behavior in a fresh fix-<n> worktree. The one
-    # input shape it misreads is a flag with a separate-word value
+    # which is the desired behavior in a fresh fix-<n> worktree. `--` also
+    # starts with `-`, so a bare `nn --` is treated as flag-only and still
+    # injects (and `nn -- prompt` correctly detects `prompt` as the user's).
+    # The one input shape it misreads is a flag with a separate-word value
     # (`nn --model opus`), where the value would look like a prompt — not a
     # shape used on a first launch today.
     user_prompt=0

--- a/bin/nn
+++ b/bin/nn
@@ -200,6 +200,14 @@ fix_marker="$PWD/.tmp/fix-gh-issue.pending"
 if [[ -f $fix_marker ]]; then
     read -r pending_prompt <"$fix_marker" || true
     rm -f "$fix_marker"
+    # Treat the first non-flag positional as a user-supplied prompt and
+    # suppress the queued one. The heuristic is intentionally simple: any
+    # arg starting with `-` is assumed to be a flag, so flag-only first
+    # launches (e.g. `nn --resume`) still get the queued prompt injected,
+    # which is the desired behavior in a fresh fix-<n> worktree. The one
+    # input shape it misreads is a flag with a separate-word value
+    # (`nn --model opus`), where the value would look like a prompt — not a
+    # shape used on a first launch today.
     user_prompt=0
     for arg in "$@"; do
         [[ $arg == -* ]] || {

--- a/bin/nn
+++ b/bin/nn
@@ -187,6 +187,32 @@ if ((clodhopper_enabled)); then
     clodhopper init --local
 fi
 
+# First-launch auto-prompt for fix-<n> worktrees. add-worktree drops a
+# one-shot marker (.tmp/fix-gh-issue.pending) holding the slash command to
+# run on the first nn launch in the worktree; we hand it to claude as the
+# initial prompt and delete the marker so it fires exactly once, surviving
+# across tmux/nono sessions. A Claude SessionStart hook can only inject
+# context, not submit a prompt, so this has to happen here at the wrapper
+# level. Skipped when the user supplies their own prompt (a non-flag
+# positional arg), though the one-shot marker is still consumed.
+auto_prompt=()
+fix_marker="$PWD/.tmp/fix-gh-issue.pending"
+if [[ -f $fix_marker ]]; then
+    read -r pending_prompt <"$fix_marker" || true
+    rm -f "$fix_marker"
+    user_prompt=0
+    for arg in "$@"; do
+        [[ $arg == -* ]] || {
+            user_prompt=1
+            break
+        }
+    done
+    if ((!user_prompt)) && [[ -n $pending_prompt ]]; then
+        auto_prompt=("$pending_prompt")
+        echo "🗯️nn: auto-running initial prompt: $pending_prompt" >&2
+    fi
+fi
+
 set -x
 # nono's allow_domain entries are injected into NO_PROXY inside the sandbox,
 # which makes HTTP clients bypass the nono proxy — and Landlock then blocks
@@ -203,4 +229,4 @@ exec nono run --profile "$profile" --allow-cwd --workdir . "${extra_allow[@]}" -
     SERENA_HOME="$PWD/.serena-home" \
     DISABLE_AUTOUPDATER=1 \
     claude --settings "$session_settings" \
-    --dangerously-skip-permissions "$@"
+    --dangerously-skip-permissions "$@" "${auto_prompt[@]+"${auto_prompt[@]}"}"

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -69,3 +69,30 @@ setup() {
     [ -d "$worktree" ]
     [ ! -f "$worktree/.gitmodules" ]
 }
+
+@test "add-worktree queues fix-gh-issue for fix-<n> branches" {
+    setup_git_repo
+    run "$ADD_WORKTREE" fix-952
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/fix-952"
+
+    [ -f "$worktree/.tmp/fix-gh-issue.pending" ]
+    grep -Fxq '/kitchen-sink:fix-gh-issue' "$worktree/.tmp/fix-gh-issue.pending"
+}
+
+@test "add-worktree queues nothing for non-fix branches" {
+    setup_git_repo
+    run "$ADD_WORKTREE" feature-branch
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/feature-branch"
+
+    [ ! -f "$worktree/.tmp/fix-gh-issue.pending" ]
+}

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -70,6 +70,22 @@ setup() {
     [ ! -f "$worktree/.gitmodules" ]
 }
 
+@test "add-worktree accepts -f and creates the worktree" {
+    # Exercises the non-empty force=(-f) array branch: -f must reach
+    # `git worktree add` as a real flag, and an empty force must not inject
+    # a stray empty arg (covered by the other tests' default path).
+    setup_git_repo
+    run "$ADD_WORKTREE" -f feature-branch
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/feature-branch"
+
+    [ -d "$worktree" ]
+}
+
 @test "add-worktree queues fix-gh-issue for fix-<n> branches" {
     setup_git_repo
     # fix-<n> is an issue branch: it must take the marker path, never the

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -72,6 +72,11 @@ setup() {
 
 @test "add-worktree queues fix-gh-issue for fix-<n> branches" {
     setup_git_repo
+    # fix-<n> is an issue branch: it must take the marker path, never the
+    # `gh pr checkout` path (that's for gh-<n> PR branches). Fail loud if gh
+    # is invoked, so the marker write can't silently coexist with a stray
+    # checkout.
+    stub_command gh 'echo "gh must not be called for issue branches" >&2; exit 1'
     run "$ADD_WORKTREE" fix-952
     [ "$status" -eq 0 ]
 

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -110,6 +110,17 @@ setup() {
     ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
 }
 
+@test "bin/nn injects nothing for an empty marker but still consumes it" {
+    mkdir -p .tmp
+    : >.tmp/fix-gh-issue.pending
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # An empty marker holds no prompt, so nothing is injected, but the
+    # one-shot marker is consumed all the same.
+    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    [ ! -f .tmp/fix-gh-issue.pending ]
+}
+
 @test "bin/nn passes no auto-prompt without the marker" {
     run "$NN"
     [ "$status" -eq 0 ]

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -85,3 +85,45 @@ setup() {
     [ "$status" -eq 0 ]
     [ ! -f "$BATS_TEST_TMPDIR/clodhopper-argv" ]
 }
+
+@test "bin/nn hands claude the queued prompt and consumes the marker" {
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # The queued slash command reaches claude as its initial prompt.
+    grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    # The marker is one-shot: consumed on the first launch.
+    [ ! -f .tmp/fix-gh-issue.pending ]
+}
+
+@test "bin/nn does not re-run the queued prompt after the marker is consumed" {
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # Second launch in the same worktree: the marker is gone, so the prompt
+    # must not fire again.
+    : >"$BATS_TEST_TMPDIR/nono-argv"
+    run "$NN"
+    [ "$status" -eq 0 ]
+    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn passes no auto-prompt without the marker" {
+    run "$NN"
+    [ "$status" -eq 0 ]
+    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn skips the queued prompt when the user supplies their own" {
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
+    run "$NN" "do something else"
+    [ "$status" -eq 0 ]
+    # The user's prompt reaches claude; the queued one is suppressed.
+    grep -Fxq 'do something else' "$BATS_TEST_TMPDIR/nono-argv"
+    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    # The one-shot marker is still consumed on the first launch.
+    [ ! -f .tmp/fix-gh-issue.pending ]
+}

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -111,13 +111,21 @@ setup() {
 }
 
 @test "bin/nn injects nothing for an empty marker but still consumes it" {
+    # Baseline: the claude argv with no marker at all.
+    run "$NN"
+    [ "$status" -eq 0 ]
+    cp "$BATS_TEST_TMPDIR/nono-argv" "$BATS_TEST_TMPDIR/nono-argv.baseline"
+
+    # An empty marker holds no prompt: the `[[ -n $pending_prompt ]]` guard
+    # must suppress injection so the claude invocation is byte-for-byte the
+    # baseline (no stray empty positional appended) — yet the one-shot
+    # marker is still consumed. Comparing full argv (not just grepping for
+    # the slash command) is what catches an empty-string arg leaking through.
     mkdir -p .tmp
     : >.tmp/fix-gh-issue.pending
     run "$NN"
     [ "$status" -eq 0 ]
-    # An empty marker holds no prompt, so nothing is injected, but the
-    # one-shot marker is consumed all the same.
-    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    diff "$BATS_TEST_TMPDIR/nono-argv" "$BATS_TEST_TMPDIR/nono-argv.baseline"
     [ ! -f .tmp/fix-gh-issue.pending ]
 }
 

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -103,7 +103,9 @@ setup() {
     run "$NN"
     [ "$status" -eq 0 ]
     # Second launch in the same worktree: the marker is gone, so the prompt
-    # must not fire again.
+    # must not fire again. Reset the recorded argv before the second run so
+    # the assertion sees only the second invocation's args (the stub uses `>`,
+    # so this is belt-and-suspenders against a future append-style stub).
     : >"$BATS_TEST_TMPDIR/nono-argv"
     run "$NN"
     [ "$status" -eq 0 ]
@@ -126,6 +128,32 @@ setup() {
     run "$NN"
     [ "$status" -eq 0 ]
     diff "$BATS_TEST_TMPDIR/nono-argv" "$BATS_TEST_TMPDIR/nono-argv.baseline"
+    [ ! -f .tmp/fix-gh-issue.pending ]
+}
+
+@test "bin/nn injects the queued prompt for a bare -- separator" {
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
+    # `--` starts with `-`, so the heuristic treats `nn --` as flag-only and
+    # still injects the queued prompt. Locks in the documented boundary.
+    run "$NN" --
+    [ "$status" -eq 0 ]
+    grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    [ ! -f .tmp/fix-gh-issue.pending ]
+}
+
+@test "bin/nn suppresses the queued prompt for the documented --model opus misread" {
+    mkdir -p .tmp
+    printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending
+    # `nn --model opus` is the one shape the heuristic misreads: the separate-
+    # word flag value `opus` looks like a user prompt, so injection is
+    # suppressed even though no real prompt was given. This test locks in that
+    # known limitation — if the heuristic is ever tightened to recognize flag
+    # values, update the comment in bin/nn and flip this assertion deliberately.
+    run "$NN" --model opus
+    [ "$status" -eq 0 ]
+    ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
+    # The one-shot marker is still consumed regardless of the misread.
     [ ! -f .tmp/fix-gh-issue.pending ]
 }
 


### PR DESCRIPTION
Closes #952

## Changes

- **`bin/add-worktree`**: when creating a `fix-<n>` issue worktree, drops a one-shot marker `.tmp/fix-gh-issue.pending` holding the slash command. `.tmp/` is gitignored, worktree-local scratch.
- **`bin/nn`**: on launch, if the marker exists, reads the queued command, deletes the marker, and hands it to `claude` as the initial prompt. Deletion makes it fire **exactly once** and survive across tmux/nono sessions. Skipped when the user supplies their own prompt (a non-flag positional), though the one-shot marker is consumed either way.

### Design notes
- The launch happens at the `nn` wrapper level (passing the command as claude's initial prompt argument) because a Claude `SessionStart` hook can only inject context, not submit a prompt — exactly as the issue spells out.
- The issue number is inferred by `/kitchen-sink:fix-gh-issue` from the `fix-<n>` branch name (matches the issue's literal example), so the marker stays a simple prompt-carrier.

## Testing

- `test/add-worktree.bats`: marker queued for `fix-<n>` branches, not for others.
- `test/nn.bats`: queued prompt reaches claude and the marker is consumed; not re-run on a second launch (re-trigger prevention); nothing injected without a marker; user-supplied prompt suppresses the queued one; empty marker injects nothing but is still consumed (full-argv comparison, mutation-verified to fail if an empty arg leaks).
- Full suite: **16/16 pass**, `precious lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)