### PR TITLE
Drop "in progress" tag from tmux session names and worktrees

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -189,16 +189,14 @@ get_github_display_name() {
     # Remove special characters that tmux doesn't like
     title=${title//[.:]/}
 
-    # blocked → 🚫 prefix; in progress → suffix. Other labels are noise in
-    # the tmux window title (and "priority: medium"-style names contain
-    # colons that tmux parses as session:window separators).
-    local prefix="" suffix=""
+    # blocked → 🚫 prefix. Other labels are noise in the tmux window title
+    # (and "priority: medium"-style names contain colons that tmux parses as
+    # session:window separators).
+    local prefix=""
     while IFS= read -r label; do
         [[ -z $label ]] && continue
         if [[ $label == "blocked" ]]; then
             prefix=" 🚫 "
-        elif [[ $label == "in progress" ]]; then
-            suffix=" [$label]"
         fi
     done <<<"$labels"
 
@@ -209,8 +207,8 @@ get_github_display_name() {
         title="${title% *}"
     fi
 
-    # Return formatted name with prefix and suffix
-    echo "${prefix}${title}${suffix}"
+    # Return formatted name with prefix
+    echo "${prefix}${title}"
 }
 
 tmux_session_name() {

--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -61,11 +61,9 @@ fi
 
 cd "$worktree_dir" || exit 1
 
-# Handle GitHub PRs and issues
+# Handle GitHub PRs
 if [[ "$type" == "pr" ]]; then
     gh pr checkout "$number"
-elif [[ "$type" == "issue" ]]; then
-    gh issue edit "$number" --add-label "in progress"
 fi
 
 # `submodule.alternateLocation=superproject` is supposed to share objects with

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -14,8 +14,8 @@ setup() {
     # tries to start one if tmux is around. Force neither path.
     export MY_INSIDE_TMUX=false
     stub_command pgrep 'exit 1'
-    # Tests use generic branch names so the fix-/gh- branches that call
-    # `gh issue edit` / `gh pr checkout` aren't exercised; stub anyway.
+    # Tests use generic branch names so the gh- branches that call
+    # `gh pr checkout` aren't exercised; stub anyway.
     stub_command gh 'exit 0'
     export GIT_CEILING_DIRECTORIES
     GIT_CEILING_DIRECTORIES="$(dirname "$BATS_TEST_TMPDIR")"


### PR DESCRIPTION
## Summary
- Remove the `[in progress]` suffix from tmux session names built by `get_github_display_name` in `bash_functions.sh`
- Stop adding the `in progress` GitHub label on issue branches in `bin/add-worktree`
- The `blocked → 🚫` prefix is unchanged

## Test plan
- `precious lint` passes on both files
- `bats test/add-worktree.bats` passes (updated a stale comment referencing `gh issue edit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)