### PR TITLE
Fix: nn: add --profile <name|path> override for the auto-discovered profile

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
         --playwright) playwright_forced=1 ;;
         --clodhopper) clodhopper_enabled=1 ;;
         --profile)
-            [[ $# -ge 2 ]] || {
+            [[ $# -ge 2 && -n "$2" ]] || {
                 echo "nn: --profile requires a value" >&2
                 exit 2
             }

--- a/bin/nn
+++ b/bin/nn
@@ -28,6 +28,10 @@ while [[ $# -gt 0 ]]; do
             profile_override="$2"
             shift
             ;;
+        --profile=)
+            echo "nn: --profile requires a value" >&2
+            exit 2
+            ;;
         --profile=*) profile_override="${1#--profile=}" ;;
         *) forwarded_args+=("$1") ;;
     esac

--- a/bin/nn
+++ b/bin/nn
@@ -268,7 +268,15 @@ set -x
 # would be overwritten by nono before claude launches).
 #
 # DISABLE_AUTOUPDATER=1 stops claude from auto-updating, pinning the version.
-exec nono run --profile "$profile" --allow-cwd --workdir . "${extra_allow[@]}" -- \
+#
+# --read-file /usr/bin/env: the sandboxed command below starts with `env`,
+# so the env binary must be readable (read implies exec) under whatever
+# profile is active. Profiles extending the claude-code base already grant
+# it; --profile overrides that stand alone don't, and would die before
+# claude launches. Granting it here keeps the wrapper's own dependency out
+# of every override profile. Redundant grants are harmless.
+exec nono run --profile "$profile" --allow-cwd --workdir . \
+    --read-file /usr/bin/env "${extra_allow[@]}" -- \
     env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 TMPDIR="$PWD/.tmp" \
     XDG_CACHE_HOME="$PWD/.tmp/cache" \
     NPM_CONFIG_CACHE="$PWD/.tmp/cache/npm" \

--- a/bin/nn
+++ b/bin/nn
@@ -7,17 +7,31 @@ set -eu -o pipefail
 # --playwright force-enables the playwright MCP regardless of e2e/ markers.
 # --clodhopper wires clodhopper's hooks into .claude/settings.local.json
 # (gitignored) for this session, so shared project repos stay clean.
+# --profile <name|path> overrides profile discovery entirely: an existing
+# file is resolved to an absolute path, anything else is passed through as
+# a profile name for nono's ~/.config/nono/profiles lookup.
 chrome_enabled=0
 playwright_forced=0
 clodhopper_enabled=0
+profile_override=""
 forwarded_args=()
-for arg in "$@"; do
-    case "$arg" in
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --chrome) chrome_enabled=1 ;;
         --playwright) playwright_forced=1 ;;
         --clodhopper) clodhopper_enabled=1 ;;
-        *) forwarded_args+=("$arg") ;;
+        --profile)
+            [[ $# -ge 2 ]] || {
+                echo "nn: --profile requires a value" >&2
+                exit 2
+            }
+            profile_override="$2"
+            shift
+            ;;
+        --profile=*) profile_override="${1#--profile=}" ;;
+        *) forwarded_args+=("$1") ;;
     esac
+    shift
 done
 set -- "${forwarded_args[@]+"${forwarded_args[@]}"}"
 
@@ -36,8 +50,22 @@ fi
 profile=""
 profile_label=""
 project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+
+# --profile short-circuits discovery: resolve an existing file to an
+# absolute path (so it works regardless of cwd), otherwise pass the value
+# through as a profile name. With the override set, the walk-up below and
+# the stack auto-detect (guarded by [[ -z "$profile" ]]) are both skipped.
+if [[ -n "$profile_override" ]]; then
+    if [[ -f "$profile_override" ]]; then
+        profile="$(realpath "$profile_override")"
+    else
+        profile="$profile_override"
+    fi
+    profile_label="$profile (--profile override)"
+fi
+
 dir="$PWD"
-while :; do
+while [[ -z "$profile" ]]; do
     if [[ -f "$dir/.nono/profile.json" ]]; then
         profile="$dir/.nono/profile.json"
         profile_label="$profile"

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -248,6 +248,17 @@ setup() {
     [ ! -f .nono/profile.json ]
 }
 
+@test "bin/nn grants /usr/bin/env to nono so override profiles can exec env" {
+    # The sandboxed command starts with `env`; a --profile override that
+    # doesn't extend the claude-code base would otherwise be unable to exec
+    # it. The grant is unconditional, so assert it on a plain launch (the
+    # stub dumps one arg per line, so the path is the line right after the
+    # --read-file flag).
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ "$(grep -Fx -A1 -m1 -- '--read-file' "$BATS_TEST_TMPDIR/nono-argv" | tail -n1)" = "/usr/bin/env" ]
+}
+
 @test "bin/nn skips the queued prompt when the user supplies their own" {
     mkdir -p .tmp
     printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -163,6 +163,60 @@ setup() {
     ! grep -Fxq '/kitchen-sink:fix-gh-issue' "$BATS_TEST_TMPDIR/nono-argv"
 }
 
+@test "bin/nn --profile passes a non-file value through as a profile name" {
+    run "$NN" --profile myprofile
+    [ "$status" -eq 0 ]
+    # The name lands as the value of nono's own --profile flag (the stub
+    # dumps one arg per line, so the value is the line right after the
+    # first --profile; -m1 keeps a forwarded duplicate from shadowing it).
+    [ "$(grep -Fx -A1 -m1 -- '--profile' "$BATS_TEST_TMPDIR/nono-argv" | tail -n1)" = "myprofile" ]
+    # And it reaches nono exactly once; a second occurrence would mean the
+    # value leaked into the forwarded claude args.
+    [ "$(grep -Fxc -- 'myprofile' "$BATS_TEST_TMPDIR/nono-argv")" -eq 1 ]
+}
+
+@test "bin/nn --profile resolves an existing file to an absolute path" {
+    echo '{"extends": ["oalders"]}' > custom-profile.json
+    run "$NN" --profile custom-profile.json
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "$(realpath custom-profile.json)" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn supports the --profile=value form" {
+    run "$NN" --profile=myprofile
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "myprofile" "$BATS_TEST_TMPDIR/nono-argv"
+    # The combined form is consumed, not forwarded to claude.
+    ! grep -Fxq -- "--profile=myprofile" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn --profile without a value fails with exit 2" {
+    run "$NN" --profile
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--profile requires a value"* ]]
+    # nono must not be launched on a usage error.
+    [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
+}
+
+@test "bin/nn --profile overrides a discovered .nono/profile.json" {
+    mkdir -p .nono
+    echo '{"extends": ["oalders"]}' > .nono/profile.json
+    run "$NN" --profile myprofile
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "myprofile" "$BATS_TEST_TMPDIR/nono-argv"
+    ! grep -Fxq -- "$BATS_TEST_TMPDIR/work/.nono/profile.json" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn --profile overrides stack auto-detection" {
+    # package.json would normally trigger the oalders-node auto-detect and
+    # write a .nono/profile.json wrapper; the override must skip both.
+    echo '{}' > package.json
+    run "$NN" --profile myprofile
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "myprofile" "$BATS_TEST_TMPDIR/nono-argv"
+    [ ! -f .nono/profile.json ]
+}
+
 @test "bin/nn skips the queued prompt when the user supplies their own" {
     mkdir -p .tmp
     printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -198,6 +198,26 @@ setup() {
     [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
 }
 
+@test "bin/nn --profile= with an empty value fails with exit 2" {
+    # `--profile=` matches the `--profile=*` glob with an empty value, which
+    # the [[ -n $profile_override ]] guard would silently treat as no
+    # override; it must error like the separate-word form instead.
+    run "$NN" --profile=
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--profile requires a value"* ]]
+    # nono must not be launched on a usage error.
+    [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
+}
+
+@test "bin/nn --profile is parsed out independently of forwarded args" {
+    run "$NN" --profile myprofile --resume
+    [ "$status" -eq 0 ]
+    # The profile reaches nono as the value of its own --profile flag.
+    [ "$(grep -Fx -A1 -m1 -- '--profile' "$BATS_TEST_TMPDIR/nono-argv" | tail -n1)" = "myprofile" ]
+    # The unrelated arg still reaches claude.
+    grep -Fxq -- "--resume" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
 @test "bin/nn --profile overrides a discovered .nono/profile.json" {
     mkdir -p .nono
     echo '{"extends": ["oalders"]}' > .nono/profile.json

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -209,6 +209,17 @@ setup() {
     [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
 }
 
+@test "bin/nn --profile '' with an empty value fails with exit 2" {
+    # An explicitly empty separate-word value passes the argument-count
+    # check, but the [[ -n $profile_override ]] guard would silently treat
+    # it as no override; it must error like the missing-value form instead.
+    run "$NN" --profile ""
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--profile requires a value"* ]]
+    # nono must not be launched on a usage error.
+    [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
+}
+
 @test "bin/nn --profile is parsed out independently of forwarded args" {
     run "$NN" --profile myprofile --resume
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #955

## Changes
- Convert `bin/nn`'s flag-parse `for` loop to a `while` loop so `--profile` can consume a separate-word value; supports both `--profile <value>` and `--profile=<value>`.
- An override naming an existing file is resolved to an absolute path via `realpath`; any other value passes through as a profile name for `~/.config/nono/profiles` lookup.
- When set, the override short-circuits both the `.nono/profile.json` walk-up discovery and the stack-detection auto-detect.
- A missing or empty value (`--profile`, `--profile=`, `--profile ""`) errors with `nn: --profile requires a value` on stderr and exit 2.
- Grant `/usr/bin/env` to nono via `--read-file` on the `nono run` line: the sandboxed command starts with `env`, which profiles extending the claude-code base already permit, but a standalone override profile would die before claude launches. Wrapper-level grant keeps the wrapper's own dependency out of every override profile.

## Testing
- 10 new bats tests in `test/nn.bats` covering name pass-through, file resolution to absolute path, the `=` form, all three empty/missing-value error paths, forwarded-arg independence, override precedence over walk-up discovery and stack auto-detect, and the `/usr/bin/env` grant in nono's argv.
- Red-green verified: the new tests fail against the pre-fix `bin/nn`; full suite passes 24/24 with the fix.
- Two code-review rounds (superpowers:code-reviewer); both review fixes (empty `--profile=` and empty separate-word value) are covered by tests. Final verdict: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)