### PR TITLE
Split nono profiles into core/net and add opt-in oalders-perl-test

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -91,7 +91,7 @@ done
 if [[ -z "$profile" ]]; then
     mixins=()
     if [[ -f "$project_root/cpanfile" || -f "$project_root/Makefile.PL" || -f "$project_root/dist.ini" ]]; then
-        mixins+=("oalders-perl")
+        mixins+=("oalders-perl" "oalders-perl-net")
     fi
     if [[ -f "$project_root/package.json" ]]; then
         mixins+=("oalders-node")

--- a/docs/superpowers/plans/2026-06-14-nono-perl-test-profile.md
+++ b/docs/superpowers/plans/2026-06-14-nono-perl-test-profile.md
@@ -1,0 +1,697 @@
+# nono permissive Perl-testing profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize the nono profiles so all network rules live in dedicated `*-net` siblings, then add an opt-in `oalders-perl-test` profile that grants open outbound network and unrestricted localhost ports for CPAN test suites while keeping the same filesystem lockdown.
+
+**Architecture:** nono's `extends` is append-only and any `allow_domain` in the chain forces proxy allowlist mode, so a permissive profile cannot remove inherited restrictions — restrictions must be lifted *out* of the shared base. Every grant sibling (filesystem/runtime) becomes net-free; all domains/ports move into `*-net` siblings; `oalders` recomposes them as `[oalders-core, oalders-net]`; `oalders-perl-test` composes only net-free grants (`[oalders-core, oalders-perl]`) so its chain has zero `allow_domain`/`open_port` ⇒ open network + open loopback ports.
+
+**Tech Stack:** nono (Landlock sandbox) JSON profiles, Bash (`bin/nn` launcher, `installer/symlinks.sh`), bats tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md`
+
+**Critical invariant:** every *existing* session must behave identically after this change. The reorg only relocates blocks — it adds and removes nothing from the default path. Each task below verifies this incrementally.
+
+**Ordering trap (read before starting):** `bin/test-nono-claude-md.sh` and any local-file `nono why`/`nono run` against `nono/oalders.json` resolve the *named* `extends` (`oalders-core`, `oalders-net`) through `~/.config/nono/profiles/`. After Task 3 flips `oalders.json` to extend the new siblings, those siblings **must already be symlinked** or resolution fails. Each task that creates a profile also symlinks it live, before any verification depends on it.
+
+---
+
+## Task 1: Create the net-free shared base `oalders-core`
+
+**Files:**
+- Create: `nono/oalders-core.json`
+- Test: live `nono policy validate`
+
+This holds today's `oalders` `extends` + `security` + cross-cutting `filesystem`, with **no** `network` block. Creating it changes nothing yet (nothing extends it).
+
+- [ ] **Step 1: Create the profile file**
+
+Create `nono/oalders-core.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-core",
+    "description": "Net-free shared base: always-on MCP/runtime siblings, security policy, and cross-cutting filesystem grants. Holds no network rules so permissive profiles can compose it without inheriting an allowlist."
+  },
+  "extends": [
+    "claude-code",
+    "oalders-uv",
+    "oalders-serena",
+    "oalders-playwright",
+    "oalders-chrome"
+  ],
+  "security": {
+    "signal_mode": "allow_same_sandbox",
+    "process_info_mode": "allow_same_sandbox",
+    "ipc_mode": "full"
+  },
+  "filesystem": {
+    "read": [
+      "/usr/libexec/gcc",
+      "/usr/local/",
+      "~/.config/gh",
+      "~/.local/bin",
+      "~/.local/share/nvim/mason",
+      "~/.npm-packages",
+      "~/dot-files/bin",
+      "~/dot-files/gitignore_global",
+      "~/dot-files/node_modules",
+      "~/dot-files/nono",
+      "~/local/bin"
+    ],
+    "allow": [
+      "/tmp/claude-1000"
+    ],
+    "read_file": [
+      "/etc/bash.bashrc",
+      "/etc/gitconfig",
+      "~/.bashrc",
+      "~/.docker/config.json",
+      "~/.gitconfig",
+      "~/dot-files/bashrc",
+      "~/dot-files/claude/CLAUDE.md",
+      "~/dot-files/claude/statusline-command.sh"
+    ],
+    "allow_file": [
+      "~/.claude/.credentials.json"
+    ],
+    "bypass_protection": [
+      "~/.bashrc",
+      "~/dot-files/bashrc"
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Symlink it live so named-extends resolution can find it**
+
+Run:
+```bash
+ln -sf ~/dot-files/nono/oalders-core.json ~/.config/nono/profiles/oalders-core.json
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Validate the profile resolves**
+
+Run: `nono policy validate ~/.config/nono/profiles/oalders-core.json`
+Expected: validates OK (no errors). It resolves `claude-code` + the four always-on siblings, all already symlinked.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nono/oalders-core.json
+git commit -m "Add net-free oalders-core base profile"
+```
+
+---
+
+## Task 2: Create the network sibling `oalders-net`
+
+**Files:**
+- Create: `nono/oalders-net.json`
+- Test: live `nono policy validate`
+
+This holds today's `oalders` `network` block (including `network_profile: null`) **plus** uv's two PyPI domains, so `oalders-uv` can go net-free in Task 4. Creating it changes nothing yet (nothing extends it).
+
+- [ ] **Step 1: Create the profile file**
+
+Create `nono/oalders-net.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-net",
+    "description": "All outbound network rules for the default oalders chain: curated allow_domain list, open_port, and the defensive network_profile:null opt-out. Includes uv's PyPI domains so the uv sibling can stay net-free."
+  },
+  "network": {
+    "network_profile": null,
+    "allow_domain": [
+      "*.anthropic.com",
+      "*.claude.ai",
+      "*.github.com",
+      "*.githubusercontent.com",
+      "api.anthropic.com",
+      "claude.ai",
+      "datatracker.ietf.org",
+      "files.pythonhosted.org",
+      "github.com",
+      "pypi.org",
+      "www.rfc-editor.org"
+    ],
+    "open_port": [80, 5000, 5001, 8080]
+  }
+}
+```
+
+- [ ] **Step 2: Symlink it live**
+
+Run:
+```bash
+ln -sf ~/dot-files/nono/oalders-net.json ~/.config/nono/profiles/oalders-net.json
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Validate the profile**
+
+Run: `nono policy validate ~/.config/nono/profiles/oalders-net.json`
+Expected: validates OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nono/oalders-net.json
+git commit -m "Add oalders-net profile carrying all outbound network rules"
+```
+
+---
+
+## Task 3: Recompose `oalders.json` from the new siblings
+
+**Files:**
+- Modify: `nono/oalders.json` (replace entire contents)
+- Test: `bin/test-nono-claude-md.sh`, behavior-preservation smoke test
+
+After this, `oalders` = `[oalders-core, oalders-net]`. `oalders-core` supplies the old `extends` + `security` + `filesystem`; `oalders-net` supplies the old `network` + uv's domains. At this point `oalders-uv` still carries its own domains too — harmless duplication (append-only dedups), removed in Task 4. Net resolved capability set: unchanged.
+
+- [ ] **Step 1: Replace `nono/oalders.json` with the composition root**
+
+Replace the entire contents of `nono/oalders.json` with exactly:
+
+```json
+{
+  "extends": [
+    "oalders-core",
+    "oalders-net"
+  ]
+}
+```
+
+- [ ] **Step 2: Verify the CLAUDE.md read grant still resolves (regression test for issue #948)**
+
+Run: `bin/test-nono-claude-md.sh`
+Expected: `ok: <repo>/nono/oalders.json grants read on <home>/.claude/CLAUDE.md`
+(This passes only because `oalders-core` is already symlinked from Task 1 and carries the `~/dot-files/claude/CLAUDE.md` `read_file` grant.)
+
+- [ ] **Step 3: Behavior-preservation smoke test**
+
+Run:
+```bash
+cd "${TMPDIR:-/tmp}" && nono run --profile oalders --allow-cwd -- true; cd - >/dev/null
+```
+Expected: exit 0, no new denial warnings.
+
+- [ ] **Step 4: Confirm the network allowlist still resolves on `oalders`**
+
+Run: `nono why --host github.com --op connect --profile ~/.config/nono/profiles/oalders.json`
+Expected: an `ALLOWED` line for `github.com` (proves the curated allowlist survived the move into `oalders-net`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nono/oalders.json
+git commit -m "Recompose oalders.json from oalders-core + oalders-net"
+```
+
+---
+
+## Task 4: Make `oalders-uv` net-free
+
+**Files:**
+- Modify: `nono/oalders-uv.json` (drop the `network` block)
+- Test: live `nono policy validate`, `nono why` for pypi
+
+`oalders-uv` is reached only via `oalders` (nothing else extends it), so dropping its domains is safe: they reappear through `oalders-net`, which `oalders` always extends.
+
+- [ ] **Step 1: Replace `nono/oalders-uv.json` with the fs-only version**
+
+Replace the entire contents of `nono/oalders-uv.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-uv",
+    "description": "uv runtime filesystem: location used by uv-installed tools (uvx, uv tool install). Net-free; PyPI domains live in oalders-net."
+  },
+  "filesystem": {
+    "read": [
+      "~/.local/share/uv"
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Validate the changed profile**
+
+Run: `nono policy validate ~/.config/nono/profiles/oalders-uv.json`
+Expected: validates OK.
+
+- [ ] **Step 3: Confirm pypi is still reachable under `oalders` (now via oalders-net)**
+
+Run: `nono why --host pypi.org --op connect --profile ~/.config/nono/profiles/oalders.json`
+Expected: an `ALLOWED` line for `pypi.org` (proves the domain survived the move from `oalders-uv` into `oalders-net`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nono/oalders-uv.json
+git commit -m "Make oalders-uv net-free; PyPI domains now in oalders-net"
+```
+
+---
+
+## Task 5: Split Perl into net-free `oalders-perl` + new `oalders-perl-net`, and update `bin/nn`
+
+**Files:**
+- Create: `nono/oalders-perl-net.json`
+- Modify: `nono/oalders-perl.json` (drop the `network` block)
+- Modify: `bin/nn:94` (append both perl mixins)
+- Test: live `nono policy validate`, manual wrapper inspection
+
+The highest-risk edit: `bin/nn` must append **both** `oalders-perl` (fs) and `oalders-perl-net` (CPAN domains). Appending only the fs half would silently strip CPAN network from every auto-detected Perl session.
+
+- [ ] **Step 1: Create `nono/oalders-perl-net.json`**
+
+Create `nono/oalders-perl-net.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-perl-net",
+    "description": "CPAN/MetaCPAN/MagPie network access for Perl sessions, split out of oalders-perl so the filesystem grants can be reused net-free."
+  },
+  "network": {
+    "allow_domain": [
+      "*.cpan.org",
+      "*.cpantesters.org",
+      "*.metacpan.org",
+      "*.perl-magpie.org",
+      "cpan.org",
+      "cpanmetadb.plackperl.org",
+      "cpantesters.org",
+      "metacpan.org"
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Symlink `oalders-perl-net` live**
+
+Run:
+```bash
+ln -sf ~/dot-files/nono/oalders-perl-net.json ~/.config/nono/profiles/oalders-perl-net.json
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Replace `nono/oalders-perl.json` with the fs-only version**
+
+Replace the entire contents of `nono/oalders-perl.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-perl",
+    "description": "Perl development mixin (filesystem only): plenv, local::lib (~/perl5), Dist::Zilla, prove, perlimports, common rc files, system C headers for XS. Net-free; CPAN domains live in oalders-perl-net."
+  },
+  "filesystem": {
+    "allow": [
+      "~/.plenv/shims"
+    ],
+    "read": [
+      "/usr/include",
+      "/usr/local/include",
+      "~/.dzil",
+      "~/.perl-cpm",
+      "~/.plenv",
+      "~/.proverc",
+      "~/dot-files/dzil",
+      "~/perl5"
+    ],
+    "read_file": [
+      "~/.config/perlimports/perlimports.toml",
+      "~/.dataprinter",
+      "~/.perlcriticrc",
+      "~/.perltidyrc",
+      "~/dot-files/.perltidyrc",
+      "~/dot-files/dataprinter",
+      "~/dot-files/perlcriticrc",
+      "~/dot-files/perlimports/perlimports.toml"
+    ]
+  }
+}
+```
+
+- [ ] **Step 4: Validate both Perl profiles**
+
+Run:
+```bash
+nono policy validate ~/.config/nono/profiles/oalders-perl.json
+nono policy validate ~/.config/nono/profiles/oalders-perl-net.json
+```
+Expected: both validate OK.
+
+- [ ] **Step 5: Update `bin/nn` to append both Perl mixins**
+
+In `bin/nn`, change the Perl detection line (currently `bin/nn:94`):
+
+```bash
+        mixins+=("oalders-perl")
+```
+
+to:
+
+```bash
+        mixins+=("oalders-perl" "oalders-perl-net")
+```
+
+- [ ] **Step 6: Manually confirm the generated wrapper contains both entries**
+
+`bin/nn` writes `.nono/profile.json` and then execs `nono`. To inspect the wrapper without launching a real session, stub `nono` to a no-op on PATH and run `nn` from a throwaway Perl repo:
+
+```bash
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/nntest.XXXXXX")
+mkdir -p "$tmp/stubs"; printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp/stubs/nono"; chmod +x "$tmp/stubs/nono"
+echo "requires 'Moo';" > "$tmp/cpanfile"
+( cd "$tmp" && PATH="$tmp/stubs:$PATH" GIT_CEILING_DIRECTORIES="$tmp" "$PWD/bin/nn" >/dev/null 2>&1 )
+cat "$tmp/.nono/profile.json"
+rm -rf "$tmp"
+```
+Expected: the printed JSON's `extends` array contains both `"oalders-perl"` and `"oalders-perl-net"` (e.g. `{"extends": ["oalders", "oalders-perl", "oalders-perl-net"]}`).
+
+> Note: the load-bearing, repeatable verification for this change is the bats test added in Task 8, which drives `bin/nn` end-to-end with a stubbed `nono`. This manual step is just a sanity glance.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nono/oalders-perl.json nono/oalders-perl-net.json bin/nn
+git commit -m "Split oalders-perl into net-free fs + oalders-perl-net; nn appends both"
+```
+
+---
+
+## Task 6: Add the `oalders-perl-test` permissive profile
+
+**Files:**
+- Create: `nono/oalders-perl-test.json`
+- Test: live `nono policy validate`, `nono why` for an off-allowlist host, port bind+connect one-liner
+
+`oalders-perl-test` = `[oalders-core, oalders-perl]`. Both are now net-free (Tasks 1, 5), so its chain has zero `allow_domain` ⇒ open outbound, and zero `open_port`/`listen_port` ⇒ unrestricted localhost binding. It still extends `claude-code` (via `oalders-core`), so all filesystem denies stay in force.
+
+- [ ] **Step 1: Create `nono/oalders-perl-test.json`**
+
+Create `nono/oalders-perl-test.json` with exactly:
+
+```json
+{
+  "meta": {
+    "name": "oalders-perl-test",
+    "description": "Opt-in permissive Perl test profile: open outbound network and unrestricted localhost ports for CPAN test suites (Test::TCP, live-network tests), with the same filesystem lockdown as oalders. Invoke via: nn --profile oalders-perl-test."
+  },
+  "extends": [
+    "oalders-core",
+    "oalders-perl"
+  ]
+}
+```
+
+- [ ] **Step 2: Symlink it live**
+
+Run:
+```bash
+ln -sf ~/dot-files/nono/oalders-perl-test.json ~/.config/nono/profiles/oalders-perl-test.json
+```
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Validate the profile**
+
+Run: `nono policy validate ~/.config/nono/profiles/oalders-perl-test.json`
+Expected: validates OK.
+
+- [ ] **Step 4: Verify open outbound — an off-allowlist host is permitted**
+
+Run: `nono why --host example.com --op connect --profile ~/.config/nono/profiles/oalders-perl-test.json`
+Expected: an `ALLOWED` line for `example.com` (no allowlist in the chain ⇒ outbound open). Contrast: the same query against `oalders` would be `DENIED`.
+
+- [ ] **Step 5: Verify open localhost ports — bind + connect to an ephemeral port**
+
+Run:
+```bash
+cd "${TMPDIR:-/tmp}" && nono run --profile oalders-perl-test --allow-cwd --read ~/.plenv -- \
+  perl -MIO::Socket::INET -e 'my $s=IO::Socket::INET->new(Listen=>5,LocalAddr=>"127.0.0.1",LocalPort=>0) or die "listen: $!";
+    my $p=$s->sockport;
+    IO::Socket::INET->new(PeerAddr=>"127.0.0.1",PeerPort=>$p) or die "connect: $!";
+    print "OK bound+connected $p\n"'; cd - >/dev/null
+```
+Expected: `OK bound+connected <some-random-port>` (the `--read ~/.plenv` is only so the plenv-shimmed `perl` is executable; it is not part of the profile).
+
+- [ ] **Step 6: Confirm the default is still locked (the reorg did not loosen `oalders`)**
+
+Run: `nono why --host example.com --op connect --profile ~/.config/nono/profiles/oalders.json`
+Expected: a `DENIED` line for `example.com` (off-allowlist host still blocked under the default profile).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add nono/oalders-perl-test.json
+git commit -m "Add opt-in permissive oalders-perl-test profile"
+```
+
+---
+
+## Task 7: Persist all four new symlinks in `installer/symlinks.sh`
+
+**Files:**
+- Modify: `installer/symlinks.sh` (add four `ln -sf` lines)
+- Test: re-run the installer's symlink lines (idempotent), confirm targets
+
+The live symlinks created in Tasks 1, 2, 5, 6 exist on this machine but won't survive a fresh install without these lines. The three *changed* files (`oalders.json`, `oalders-perl.json`, `oalders-uv.json`) already have symlink lines and need none added.
+
+- [ ] **Step 1: Add the four new symlink lines**
+
+In `installer/symlinks.sh`, find the block of `oalders-*.json` symlink lines (currently `installer/symlinks.sh:99-109`). Add these four lines into that block, keeping it readable:
+
+Insert after the `oalders-chrome.json` line (`installer/symlinks.sh:99`):
+```bash
+ln -sf $prefix/nono/oalders-core.json ~/.config/nono/profiles/oalders-core.json
+```
+
+Insert after the `oalders-hugo.json` line:
+```bash
+ln -sf $prefix/nono/oalders-net.json ~/.config/nono/profiles/oalders-net.json
+```
+
+Insert after the `oalders-perl.json` line:
+```bash
+ln -sf $prefix/nono/oalders-perl-net.json ~/.config/nono/profiles/oalders-perl-net.json
+ln -sf $prefix/nono/oalders-perl-test.json ~/.config/nono/profiles/oalders-perl-test.json
+```
+
+- [ ] **Step 2: Confirm the four symlinks point at the repo files**
+
+Run:
+```bash
+for p in oalders-core oalders-net oalders-perl-net oalders-perl-test; do
+  readlink ~/.config/nono/profiles/$p.json
+done
+```
+Expected: four lines, each ending in `dot-files/nono/<name>.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add installer/symlinks.sh
+git commit -m "Symlink the four new nono profiles in installer/symlinks.sh"
+```
+
+---
+
+## Task 8: Regression-test the two-entry Perl append in `test/nn.bats`
+
+**Files:**
+- Modify: `test/nn.bats` (add one `@test`)
+- Test: `bats test/nn.bats`
+
+Locks in the highest-risk edit from Task 5 — that auto-detection appends **both** Perl mixins. The existing suite stubs `nono` and asserts the generated wrapper; this test follows the same pattern as the Hugo detection test.
+
+- [ ] **Step 1: Add the regression test**
+
+Append this `@test` to the end of `test/nn.bats`:
+
+```bash
+@test "bin/nn auto-detect appends both oalders-perl and oalders-perl-net" {
+    # A cpanfile marks a Perl repo; detection must compose BOTH the fs mixin
+    # (oalders-perl) and the network mixin (oalders-perl-net). Appending only
+    # the fs half would silently strip CPAN network from auto-detected sessions.
+    echo "requires 'Moo';" > cpanfile
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f .nono/profile.json ]
+    grep -Fq '"oalders-perl"' .nono/profile.json
+    grep -Fq '"oalders-perl-net"' .nono/profile.json
+}
+```
+
+- [ ] **Step 2: Run the new test and confirm it passes**
+
+Run: `bats test/nn.bats -f "appends both oalders-perl"`
+Expected: `1 test, 0 failures`.
+
+- [ ] **Step 3: Run the full nn suite to confirm no regressions**
+
+Run: `bats test/nn.bats`
+Expected: all tests pass, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/nn.bats
+git commit -m "Test that nn auto-detect appends both Perl mixins"
+```
+
+---
+
+## Task 9: Update `nono/CLAUDE.md` documentation
+
+**Files:**
+- Modify: `nono/CLAUDE.md`
+- Test: `markdownlint-cli nono/CLAUDE.md` (if available), manual read-through
+
+Document the core/net split and the opt-in permissive profile, and fix every now-stale reference. The reorg moves the always-on siblings and the cross-cutting blocks out of `oalders.json` into `oalders-core`, and all network into `*-net` siblings — several sections currently say otherwise.
+
+- [ ] **Step 1: Update the "Files" list**
+
+In the `## Files` section, add bullets describing the new always-on composition. After the `oalders.json` bullet, add:
+
+```markdown
+- `oalders-core.json` — net-free shared base (always-on MCP/runtime siblings, security policy, cross-cutting filesystem grants), symlinked to `~/.config/nono/profiles/oalders-core.json`
+- `oalders-net.json` — all outbound network rules for the default chain (curated `allow_domain`, `open_port`, `network_profile: null`), symlinked to `~/.config/nono/profiles/oalders-net.json`
+```
+
+Also change the `oalders.json` bullet's description to reflect that it is now a composition root: replace "nono profile" with "nono profile composition root (`extends: [oalders-core, oalders-net]`)".
+
+- [ ] **Step 2: Add a "Core/net split" subsection under "Sibling profiles"**
+
+Immediately under the `## Sibling profiles` intro paragraph (before `### Always-on`), insert:
+
+```markdown
+### Net-free base vs. network siblings
+
+`oalders` is now `{"extends": ["oalders-core", "oalders-net"]}`:
+
+- **`oalders-core`** holds the always-on siblings, the `security` block, and the cross-cutting `filesystem` grants — and **no `network`**.
+- **`oalders-net`** holds *all* outbound rules: the curated `allow_domain` list, `open_port`, the defensive `network_profile: null`, and uv's PyPI domains.
+
+The rule that forces this split: nono's `extends` is append-only, and **any** `allow_domain` anywhere in the chain flips nono into proxy allowlist mode (default-deny outbound). There is no way to remove an inherited domain. So every grant sibling (filesystem/runtime) is kept net-free, and all domains/ports live in dedicated `*-net` siblings. A profile that needs open network — like `oalders-perl-test` — composes only net-free grants and adds no `*-net`, leaving outbound and localhost ports unrestricted.
+```
+
+- [ ] **Step 3: Fix the "Always-on" heading and intro**
+
+In `### Always-on (mixed in via `oalders.json`'s own `extends`)`, change the heading and its intro paragraph to attribute the always-on siblings to `oalders-core`, not `oalders.json`. Replace the heading with:
+
+```markdown
+### Always-on (mixed in via `oalders-core`'s `extends`)
+```
+
+And replace the intro sentence "so they go in `oalders.json`'s `extends` list rather than per-repo detection." with "so they go in `oalders-core`'s `extends` list (which `oalders` always pulls in) rather than per-repo detection."
+
+- [ ] **Step 4: Fix the `oalders-uv` row in the Always-on table**
+
+In the Always-on table, change the `oalders-uv` row's "Owns" cell from:
+
+```markdown
+| `oalders-uv`        | `~/.local/share/uv` (uv runtime — used by `uvx` and `uv tool install`)                 |
+```
+
+to:
+
+```markdown
+| `oalders-uv`        | `~/.local/share/uv` (uv runtime — used by `uvx` and `uv tool install`). Net-free; PyPI domains live in `oalders-net`. |
+```
+
+- [ ] **Step 5: Fix the `oalders-perl` row in the Project-detected table**
+
+In the Project-detected table, change the `oalders-perl` row's "Owns" cell to drop the network claim and point at the new sibling. Replace:
+
+```markdown
+| `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), CPAN/MagPie network, XS system C headers (`/usr/include`, `/usr/local/include`) |
+```
+
+with:
+
+```markdown
+| `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), XS system C headers (`/usr/include`, `/usr/local/include`). Net-free; CPAN/MetaCPAN/MagPie network is in the paired `oalders-perl-net` (appended alongside it by `nn`). |
+```
+
+- [ ] **Step 6: Document `oalders-perl-test` in the "Opt-in only" section**
+
+In `### Opt-in only (no auto-detection)`, add a row to the opt-in table and an invocation note. Add this row after the `oalders-terraform` row:
+
+```markdown
+| `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
+```
+
+And after the existing terraform `.nono/profile.json` example, add:
+
+```markdown
+`oalders-perl-test` is invoked directly rather than via a per-repo wrapper, because it intentionally drops the network/port restrictions a wrapper extending `oalders` would re-impose:
+
+```
+nn --profile oalders-perl-test
+```
+```
+
+- [ ] **Step 7: Repoint the "Cross-cutting" guidance in "Extending the profile"**
+
+In `## Extending the profile`, step 2, the "Cross-cutting" bullet currently says "→ `oalders.json`". Change it to "→ `oalders-core.json` (the net-free base). New network domains/ports → `oalders-net.json`."
+
+- [ ] **Step 8: Repoint the "Cross-cutting bits" subsection**
+
+Change the `### Cross-cutting bits that stay in `oalders.json`` heading to:
+
+```markdown
+### Cross-cutting bits that live in `oalders-core.json`
+```
+
+and update its intro sentence "so they live in the base:" → "so they live in `oalders-core` (the net-free base that `oalders` always extends):". The bullet list of paths is unchanged (those grants moved verbatim into `oalders-core`).
+
+- [ ] **Step 9: Lint and read through**
+
+Run: `markdownlint-cli nono/CLAUDE.md` (skip if the tool isn't installed).
+Expected: no errors. Then re-read the file to confirm no remaining sentence claims `oalders.json` directly owns `extends`/`security`/`filesystem`/`network`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add nono/CLAUDE.md
+git commit -m "Document core/net profile split and oalders-perl-test"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Validate every touched profile once more**
+
+Run:
+```bash
+for p in oalders oalders-core oalders-net oalders-uv oalders-perl oalders-perl-net oalders-perl-test; do
+  echo "== $p =="
+  nono policy validate ~/.config/nono/profiles/$p.json
+done
+```
+Expected: all validate OK.
+
+- [ ] **Step 2: Re-run the issue-#948 regression and the full nn suite**
+
+Run:
+```bash
+bin/test-nono-claude-md.sh
+bats test/nn.bats
+```
+Expected: the first prints `ok: ...`; the second reports 0 failures.
+
+- [ ] **Step 3: Lint shell**
+
+Run: `precious lint` (or `shfmt -d -s -i 4 bin/nn installer/symlinks.sh`)
+Expected: no diffs / no lint errors on the touched shell files.
+```

--- a/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
+++ b/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
@@ -75,8 +75,9 @@ new files follow the sibling convention, not `oalders`'s).
 | File | Change |
 |------|--------|
 | `bin/nn` | Perl detection appends **both** `oalders-perl` and `oalders-perl-net` to `mixins` (was just `oalders-perl`). **Regression risk:** appending only `oalders-perl` (the fs half) would silently strip all CPAN network access from every auto-detected Perl session. Both entries must land together; this is the single highest-risk edit. |
+| `test/nn.bats` | Add a regression case asserting the auto-detected Perl wrapper's `extends` contains **both** `oalders-perl` and `oalders-perl-net`. This is the single highest-risk edit (C3) and currently has zero coverage; the existing bats suite stubs `nono` and asserts argv plumbing, so this fits the harness. |
 | `installer/symlinks.sh` | Symlink exactly the four new profiles into `~/.config/nono/profiles/`: `oalders-core.json`, `oalders-net.json`, `oalders-perl-net.json`, `oalders-perl-test.json`. (`oalders.json`/`oalders-perl.json`/`oalders-uv.json` already have symlinks and only change content.) |
-| `nono/CLAUDE.md` | Document the core/net split, the core principle, and the opt-in permissive profile. Also fix now-stale rows in the existing tables: the `oalders-uv` row (no longer owns network) and the `oalders-perl` row (network moves to `oalders-perl-net`). |
+| `nono/CLAUDE.md` | Document the core/net split, the core principle, and the opt-in permissive profile. Also fix now-stale rows in the existing tables: the `oalders-uv` row (no longer owns network) and the `oalders-perl` row (network moves to `oalders-perl-net`). Further stale spots to update: the "Files" list (mention the new always-on `oalders-core`/`oalders-net`); the "Always-on, mixed in via `oalders.json`'s own extends" heading (always-on siblings are now pulled by `oalders-core`, not `oalders.json` directly); and the "Cross-cutting bits that stay in `oalders.json`" section plus the "Extending the profile" guidance (cross-cutting blocks move to `oalders-core` — point both at it). |
 
 ## Behavior preservation (the critical invariant)
 
@@ -131,6 +132,15 @@ default path.
   where allowlist mode is in effect.)
 - **Validation:** each new/changed profile must pass
   `nono policy validate ~/.config/nono/profiles/<file>.json`.
+- **Symlink-before-verify ordering trap:** `bin/test-nono-claude-md.sh` resolves
+  the repo-local `nono/oalders.json` (source of truth) via `nono why`, but the
+  *named* `extends` inside it (`oalders-core`, `oalders-net`) still resolve
+  through `~/.config/nono/profiles/`. After the reorg the `~/.claude/CLAUDE.md`
+  read grant moves from `oalders.json`'s inline `filesystem` block into
+  `oalders-core`, so this regression test (and any local-file `nono why`/`nono
+  run` against `nono/oalders.json`) **fails until the four new profiles are
+  symlinked**. Run `installer/symlinks.sh` *before* re-running the test or any
+  smoke test on the branch.
 
 ## Testing / verification
 

--- a/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
+++ b/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
@@ -59,20 +59,24 @@ model along the one axis that matters for nono: restrictions vs. grants.
 | File | Change | Holds |
 |------|--------|-------|
 | `oalders-core.json` | **new** | `extends: [claude-code, oalders-uv, oalders-serena, oalders-playwright, oalders-chrome]`, `security` block, cross-cutting `filesystem` block. **No `network`.** The net-free shared base. |
-| `oalders-net.json` | **new** | The curated `allow_domain` list + `open_port` from today's `oalders`, **plus** `pypi.org`/`files.pythonhosted.org` moved out of `oalders-uv`. |
+| `oalders-net.json` | **new** | `network_profile: null` + the curated `allow_domain` list + `open_port` from today's `oalders`, **plus** `pypi.org`/`files.pythonhosted.org` moved out of `oalders-uv`. The `network_profile: null` must ride along: it is the documented defensive opt-out (see `nono/CLAUDE.md`, "Why `network_profile` is set to `null`") and must not be dropped in the move. |
 | `oalders-uv.json` | **changed** | Drop its `network` block → fs-only (`~/.local/share/uv`). |
 | `oalders.json` | **changed** | Becomes `{"extends": ["oalders-core", "oalders-net"]}`. |
 | `oalders-perl.json` | **changed** | Drop its `network` block → fs-only. |
 | `oalders-perl-net.json` | **new** | The CPAN/MagPie `allow_domain` list moved out of `oalders-perl`. |
 | `oalders-perl-test.json` | **new (opt-in)** | `extends: [oalders-core, oalders-perl]`. No `network` block ⇒ open outbound + unrestricted localhost ports, with full MCP runtimes, perl fs grants, and the same fs lockdown. |
 
+Each new profile carries a `meta.name`/`meta.description` block, matching the
+convention of the existing siblings (`oalders.json` itself has none today; the
+new files follow the sibling convention, not `oalders`'s).
+
 ### Non-profile changes
 
 | File | Change |
 |------|--------|
-| `bin/nn` | Perl detection appends **both** `oalders-perl` and `oalders-perl-net` to `mixins` (was just `oalders-perl`). |
-| `installer/symlinks.sh` | Symlink the four new profiles into `~/.config/nono/profiles/`. |
-| `nono/CLAUDE.md` | Document the core/net split, the core principle, and the opt-in permissive profile. |
+| `bin/nn` | Perl detection appends **both** `oalders-perl` and `oalders-perl-net` to `mixins` (was just `oalders-perl`). **Regression risk:** appending only `oalders-perl` (the fs half) would silently strip all CPAN network access from every auto-detected Perl session. Both entries must land together; this is the single highest-risk edit. |
+| `installer/symlinks.sh` | Symlink exactly the four new profiles into `~/.config/nono/profiles/`: `oalders-core.json`, `oalders-net.json`, `oalders-perl-net.json`, `oalders-perl-test.json`. (`oalders.json`/`oalders-perl.json`/`oalders-uv.json` already have symlinks and only change content.) |
+| `nono/CLAUDE.md` | Document the core/net split, the core principle, and the opt-in permissive profile. Also fix now-stale rows in the existing tables: the `oalders-uv` row (no longer owns network) and the `oalders-perl` row (network moves to `oalders-perl-net`). |
 
 ## Behavior preservation (the critical invariant)
 
@@ -88,8 +92,12 @@ default path.
   oalders-perl-net`. `oalders-perl` (fs) + `oalders-perl-net` (CPAN domains)
   together equal today's `oalders-perl`. Zero change.
 - `oalders-uv` loses its domains but they reappear via `oalders-net` (always
-  extended by `oalders`). Zero change for any consumer that reaches uv through
-  `oalders`.
+  extended by `oalders`). `oalders-uv` is reached *only* through `oalders`
+  (nothing else extends it), so every uv consumer still gets pypi via
+  `oalders-net`. Zero change.
+- `network_profile: null` moves from `oalders`'s inline `network` block into
+  `oalders-net`, which `oalders` always extends — so it still resolves on
+  `oalders`. Without it the move would silently drop the defensive opt-out.
 
 ## The permissive profile
 
@@ -113,10 +121,14 @@ default path.
 
 - **MCP servers (serena/uv):** `oalders-perl-test` includes `oalders-core`, which
   carries the uv runtime fs grant and the serena/playwright/chrome grants, so
-  MCP servers launch the same as in a normal session. uv's pypi domains are
-  *not* in this profile's chain; `uvx` resolving an already-installed serena does
-  not need pypi at runtime, so this is acceptable. If a future need arises to
-  install via uv inside a permissive session, add the domains then.
+  MCP servers launch the same as in a normal session. `nn`'s per-launch serena
+  setup (`SERENA_HOME=$PWD/.serena-home` + seed `serena_config.yml`) runs for
+  *every* invocation including `nn --profile oalders-perl-test`, so serena is
+  configured identically. The fact that uv's pypi domains are not in this chain
+  is **not** a problem here: `oalders-perl-test` has *open* outbound (no
+  allowlist), so `uvx` can reach pypi like any host if it needs to revalidate or
+  fetch. (pypi being in `oalders-net` only matters for the locked `oalders` path,
+  where allowlist mode is in effect.)
 - **Validation:** each new/changed profile must pass
   `nono policy validate ~/.config/nono/profiles/<file>.json`.
 

--- a/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
+++ b/docs/superpowers/specs/2026-06-13-nono-perl-test-profile-design.md
@@ -1,0 +1,145 @@
+# nono permissive Perl-testing profile design
+
+## Purpose
+
+CPAN module test suites often need capabilities the default `oalders` nono
+profile denies: calling out to arbitrary internet hosts, and binding to a
+localhost port (frequently a random/ephemeral one, e.g. `Test::TCP`). Provide
+an **opt-in** profile, `oalders-perl-test`, that grants open outbound network
+and unrestricted localhost binding for these sessions, while keeping the same
+filesystem lockdown as every other session.
+
+## Background: why this needs a reorganization, not a mixin
+
+nono's profile `extends` is **append-only** for array fields including
+`allow_domain`, `open_port`, and `listen_port`. There is no mechanism to
+*remove* an inherited entry. Two consequences, both verified:
+
+1. **Any `allow_domain` entry anywhere in the inheritance chain flips nono into
+   proxy allowlist mode** (default-deny outbound; only listed domains pass).
+   Confirmed by lived experience: `oalders` sets `allow_domain`, and arbitrary
+   internet is blocked under it.
+2. **`open_port`/`listen_port` are allowlists; with *no* port rules in the
+   chain, localhost binding is unrestricted.** Verified 2026-06-13:
+
+   ```
+   cd "$TMPDIR" && nono run --allow-cwd --read ~/.plenv -- perl -MIO::Socket::INET \
+     -e 'my $s=IO::Socket::INET->new(Listen=>5,LocalAddr=>"127.0.0.1",LocalPort=>0) or die;
+         my $p=$s->sockport;
+         IO::Socket::INET->new(PeerAddr=>"127.0.0.1",PeerPort=>$p) or die;
+         print "OK $p\n"'
+   # => net outbound allowed; "OK bound+connected 46745"
+   ```
+
+Therefore a profile that wants open network and open ports **cannot** be a mixin
+layered on top of `oalders` — it would inherit `oalders`'s `allow_domain` and
+`open_port` and be stuck with them. The restrictions must be lifted *out* of the
+shared base so a permissive profile can compose the grants without them.
+
+A second finding shaped the design: `oalders-uv` itself sets
+`allow_domain: [pypi.org, files.pythonhosted.org]`. Because `oalders` always
+extends `oalders-uv`, that sibling also forces allowlist mode. So it is not
+enough to de-restrict `oalders`; **every** grant sibling pulled into the shared
+base must be net-free, with all domains/ports consolidated into dedicated `*-net`
+siblings.
+
+## Core principle
+
+> Every grant sibling (filesystem/runtime) is **net-free**. *All* `allow_domain`,
+> `open_port`, and `listen_port` live in dedicated `*-net` siblings. Restrictions
+> are **composed on top** of a net-free base, never inherited from it.
+
+This extends the repository's existing "composable single-purpose siblings"
+model along the one axis that matters for nono: restrictions vs. grants.
+
+## Architecture
+
+### New / changed profiles
+
+| File | Change | Holds |
+|------|--------|-------|
+| `oalders-core.json` | **new** | `extends: [claude-code, oalders-uv, oalders-serena, oalders-playwright, oalders-chrome]`, `security` block, cross-cutting `filesystem` block. **No `network`.** The net-free shared base. |
+| `oalders-net.json` | **new** | The curated `allow_domain` list + `open_port` from today's `oalders`, **plus** `pypi.org`/`files.pythonhosted.org` moved out of `oalders-uv`. |
+| `oalders-uv.json` | **changed** | Drop its `network` block → fs-only (`~/.local/share/uv`). |
+| `oalders.json` | **changed** | Becomes `{"extends": ["oalders-core", "oalders-net"]}`. |
+| `oalders-perl.json` | **changed** | Drop its `network` block → fs-only. |
+| `oalders-perl-net.json` | **new** | The CPAN/MagPie `allow_domain` list moved out of `oalders-perl`. |
+| `oalders-perl-test.json` | **new (opt-in)** | `extends: [oalders-core, oalders-perl]`. No `network` block ⇒ open outbound + unrestricted localhost ports, with full MCP runtimes, perl fs grants, and the same fs lockdown. |
+
+### Non-profile changes
+
+| File | Change |
+|------|--------|
+| `bin/nn` | Perl detection appends **both** `oalders-perl` and `oalders-perl-net` to `mixins` (was just `oalders-perl`). |
+| `installer/symlinks.sh` | Symlink the four new profiles into `~/.config/nono/profiles/`. |
+| `nono/CLAUDE.md` | Document the core/net split, the core principle, and the opt-in permissive profile. |
+
+## Behavior preservation (the critical invariant)
+
+Every existing session must behave **identically** after this change. The
+refactor only relocates blocks; it adds no grants and removes none from the
+default path.
+
+- `oalders` = `[oalders-core, oalders-net]`. `oalders-core` supplies what was
+  `oalders`'s `extends` + `security` + `filesystem`; `oalders-net` supplies what
+  was `oalders`'s `network`, plus uv's two domains (which previously arrived via
+  `oalders-uv`). Net effect on the resolved capability set: zero change.
+- Normal Perl sessions: `nn` now composes `oalders + oalders-perl +
+  oalders-perl-net`. `oalders-perl` (fs) + `oalders-perl-net` (CPAN domains)
+  together equal today's `oalders-perl`. Zero change.
+- `oalders-uv` loses its domains but they reappear via `oalders-net` (always
+  extended by `oalders`). Zero change for any consumer that reaches uv through
+  `oalders`.
+
+## The permissive profile
+
+`oalders-perl-test`:
+
+- **Opt-in only.** Not auto-detected by `nn`; invoked explicitly with
+  `nn --profile oalders-perl-test`. `nn`'s existing `--profile` override path
+  resolves the name against `~/.config/nono/profiles/` and already adds
+  `--read-file /usr/bin/env`.
+- **Open network:** no `allow_domain` anywhere in its chain
+  (`oalders-core` and `oalders-perl` are both net-free), so nono leaves outbound
+  open.
+- **Open localhost ports:** no `open_port`/`listen_port` in its chain, so binding
+  to any loopback port (including ephemeral) is unrestricted.
+- **Same filesystem lockdown:** it still extends `claude-code` (via
+  `oalders-core`), so `deny_credentials`, `deny_keychains_*`, `deny_browser_*`,
+  `deny_shell_history`, `deny_shell_configs`, etc. all still apply. Only network
+  and loopback ports open up — the dangerous filesystem surface stays denied.
+
+## Error handling / failure modes
+
+- **MCP servers (serena/uv):** `oalders-perl-test` includes `oalders-core`, which
+  carries the uv runtime fs grant and the serena/playwright/chrome grants, so
+  MCP servers launch the same as in a normal session. uv's pypi domains are
+  *not* in this profile's chain; `uvx` resolving an already-installed serena does
+  not need pypi at runtime, so this is acceptable. If a future need arises to
+  install via uv inside a permissive session, add the domains then.
+- **Validation:** each new/changed profile must pass
+  `nono policy validate ~/.config/nono/profiles/<file>.json`.
+
+## Testing / verification
+
+1. **Behavior-preservation smoke test** (run from `$TMPDIR`, per `nono/CLAUDE.md`):
+   `cd "$TMPDIR" && nono run --profile oalders --allow-cwd -- true` succeeds with
+   no new denials.
+2. **Permissive network:** under `oalders-perl-test`, an outbound request to a
+   host *not* in any allowlist (e.g. `example.com`) succeeds.
+3. **Permissive ports:** under `oalders-perl-test`, the bind+connect one-liner
+   above succeeds (it already passes with no port rules; confirm the profile
+   chain introduces none).
+4. **Default still locked:** under `oalders` (or an auto-detected perl wrapper),
+   the same off-allowlist outbound request still fails, and binding an
+   off-list port still fails — proving the reorg did not loosen the default.
+
+## Out of scope
+
+- No `nn` convenience flag (e.g. `--perl-test`); `nn --profile oalders-perl-test`
+  is sufficient.
+- No splitting of `oalders-node` / `oalders-go` / `oalders-hugo` along the
+  fs/net axis. Only `oalders-uv` and `oalders-perl` are split, because they are
+  the siblings the permissive Perl profile must reuse net-free. Other siblings
+  can adopt the pattern later if a permissive variant is ever needed.
+- No permissive variants for other stacks. This design delivers Perl only.

--- a/installer/docker.sh
+++ b/installer/docker.sh
@@ -32,6 +32,6 @@ echo \
 
 sudo apt-get update
 
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 sudo docker run hello-world

--- a/installer/symlinks.sh
+++ b/installer/symlinks.sh
@@ -97,10 +97,14 @@ ln -sf $prefix/claude-pulse/config.json ~/.config/claude-pulse/config.json
 ln -sf $prefix/mcphub/servers.json ~/.config/mcphub/servers.json
 ln -sf $prefix/nix/nix.conf ~/.config/nix/nix.conf
 ln -sf $prefix/nono/oalders-chrome.json ~/.config/nono/profiles/oalders-chrome.json
+ln -sf $prefix/nono/oalders-core.json ~/.config/nono/profiles/oalders-core.json
 ln -sf $prefix/nono/oalders-go.json ~/.config/nono/profiles/oalders-go.json
 ln -sf $prefix/nono/oalders-hugo.json ~/.config/nono/profiles/oalders-hugo.json
+ln -sf $prefix/nono/oalders-net.json ~/.config/nono/profiles/oalders-net.json
 ln -sf $prefix/nono/oalders-node.json ~/.config/nono/profiles/oalders-node.json
 ln -sf $prefix/nono/oalders-perl.json ~/.config/nono/profiles/oalders-perl.json
+ln -sf $prefix/nono/oalders-perl-net.json ~/.config/nono/profiles/oalders-perl-net.json
+ln -sf $prefix/nono/oalders-perl-test.json ~/.config/nono/profiles/oalders-perl-test.json
 ln -sf $prefix/nono/oalders-playwright.json ~/.config/nono/profiles/oalders-playwright.json
 ln -sf $prefix/nono/oalders-serena.json ~/.config/nono/profiles/oalders-serena.json
 ln -sf $prefix/nono/oalders-snap.json ~/.config/nono/profiles/oalders-snap.json

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -4,7 +4,9 @@ Wraps Claude Code in the [nono](https://nono.sh/) sandbox. Invoke via `nn` (from
 
 ## Files
 
-- `oalders.json` — nono profile, symlinked to `~/.config/nono/profiles/oalders.json`
+- `oalders.json` — nono profile composition root (`extends: [oalders-core, oalders-net]`), symlinked to `~/.config/nono/profiles/oalders.json`
+- `oalders-core.json` — net-free shared base (always-on MCP/runtime siblings, security policy, cross-cutting filesystem grants), symlinked to `~/.config/nono/profiles/oalders-core.json`
+- `oalders-net.json` — all outbound network rules for the default chain (curated `allow_domain`, `open_port`, `network_profile: null`), symlinked to `~/.config/nono/profiles/oalders-net.json`
 - `claude-settings.json` — `{"sandbox": {"enabled": false}}` passed to claude via `--settings`, symlinked to `~/.config/nono/claude-settings.json` (so claude's built-in sandbox stays off while nono does the real work)
 
 ## Per-project profiles
@@ -19,13 +21,22 @@ Project-local profiles can `"extends": "oalders"` to layer additional grants on 
 
 `extends` accepting a list comes from nono PR #399; sibling profiles must therefore live as named profiles in `~/.config/nono/profiles/` so the lookup resolves.
 
-### Always-on (mixed in via `oalders.json`'s own `extends`)
+### Net-free base vs. network siblings
 
-These are global infrastructure — MCP servers Claude relies on, and their runtimes — so they go in `oalders.json`'s `extends` list rather than per-repo detection.
+`oalders` is now `{"extends": ["oalders-core", "oalders-net"]}`:
+
+- **`oalders-core`** holds the always-on siblings, the `security` block, and the cross-cutting `filesystem` grants — and **no `network`**.
+- **`oalders-net`** holds *all* outbound rules: the curated `allow_domain` list, `open_port`, the defensive `network_profile: null`, and uv's PyPI domains.
+
+The rule that forces this split: nono's `extends` is append-only, and **any** `allow_domain` anywhere in the chain flips nono into proxy allowlist mode (default-deny outbound). There is no way to remove an inherited domain. So every grant sibling (filesystem/runtime) is kept net-free, and all domains/ports live in dedicated `*-net` siblings. A profile that needs open network — like `oalders-perl-test` — composes only net-free grants and adds no `*-net`, leaving outbound and localhost ports unrestricted.
+
+### Always-on (mixed in via `oalders-core`'s `extends`)
+
+These are global infrastructure — MCP servers Claude relies on, and their runtimes — so they go in `oalders-core`'s `extends` list (which `oalders` always pulls in) rather than per-repo detection.
 
 | Profile             | Owns                                                                                   |
 | ------------------- | -------------------------------------------------------------------------------------- |
-| `oalders-uv`        | `~/.local/share/uv` (uv runtime — used by `uvx` and `uv tool install`)                 |
+| `oalders-uv`        | `~/.local/share/uv` (uv runtime — used by `uvx` and `uv tool install`). Net-free; PyPI domains live in `oalders-net`. |
 | `oalders-serena`    | `~/.serena` (serena MCP config/logs/memories)                                          |
 | `oalders-playwright`| `~/.cache/ms-playwright` (Chromium bundle), `/dev/shm` (browser IPC)                   |
 | `oalders-chrome`    | `/opt/google/chrome` (browser binary), `~/.cache/superpowers` (browser session dirs)   |
@@ -36,7 +47,7 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 
 | Profile         | Markers at repo root                  | Owns                                                                               |
 | --------------- | ------------------------------------- | ---------------------------------------------------------------------------------- |
-| `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), CPAN/MagPie network, XS system C headers (`/usr/include`, `/usr/local/include`) |
+| `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), XS system C headers (`/usr/include`, `/usr/local/include`). Net-free; CPAN/MetaCPAN/MagPie network is in the paired `oalders-perl-net` (appended alongside it by `nn`). |
 | `oalders-node`  | `package.json`                        | `*.npmjs.org`, `registry.npmjs.org` (npm registry network access for installs)     |
 | `oalders-go`    | `go.mod`                              | Go toolchain (`go_runtime` group), build/module/lint caches (`~/.cache/go-build`, `~/.cache/golangci-lint`, `~/go/pkg/mod`), module proxy + checksum DB (`proxy.golang.org`, `sum.golang.org`), and cgo system headers (`/usr/include`, `/usr/local/include`, `/opt/homebrew/include`, pkg-config dirs, `/Library/Developer/CommandLineTools`) |
 | `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). When Hugo matches, `nn` also appends `oalders-snap` to the mixin list because Hugo on Linux is typically snap-installed. |
@@ -55,6 +66,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 | Profile             | Owns                                                                                  |
 | ------------------- | ------------------------------------------------------------------------------------- |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
+| `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
 
 Opt-in via per-repo `.nono/profile.json`:
 
@@ -62,11 +74,17 @@ Opt-in via per-repo `.nono/profile.json`:
 {"extends": ["oalders", "oalders-terraform"]}
 ```
 
+`oalders-perl-test` is invoked directly rather than via a per-repo wrapper, because it intentionally drops the network/port restrictions a wrapper extending `oalders` would re-impose:
+
+```
+nn --profile oalders-perl-test
+```
+
 ### Adding a new sibling
 
 1. Write `nono/oalders-<topic>.json` standalone (no `extends`).
 2. Add a symlink line in `installer/symlinks.sh` for `~/.config/nono/profiles/oalders-<topic>.json`.
-3. If it should be always-on, append `"oalders-<topic>"` to `oalders.json`'s `extends`. If it's per-project, add a detection block in `bin/nn` that appends `"oalders-<topic>"` to `mixins`.
+3. If it should be always-on, append `"oalders-<topic>"` to `oalders-core.json`'s `extends` (net-free grants); a sibling that adds outbound domains/ports instead folds into `oalders-net.json` (or is added to `oalders.json`'s `extends` alongside `oalders-net`). If it's per-project, add a detection block in `bin/nn` that appends `"oalders-<topic>"` to `mixins`.
 
 ### Wrapper lifecycle
 
@@ -100,14 +118,14 @@ The `claude-code` network bundle (`network.network_profile`) sets up nono's reve
 
 Surfaced 2026-04-30 after claude auto-updated to a version that respects `ANTHROPIC_BASE_URL`. Earlier claude went to `api.anthropic.com` directly and tunneled through `HTTPS_PROXY`, dodging the intercept.
 
-Workaround: set `"network_profile": null` in `oalders.json` and replace the curated bundle with an explicit `allow_domain` list (Anthropic, GitHub, npm, Go module proxy). The explicit `null` is the documented opt-out pattern — see nono's `docs/cli/clients/claude-code.mdx` (`claude-code-netopen` example). Today the parent `claude-code` profile doesn't set `network_profile`, so omitting the field would also work, but `null` is defensive against a future nono release adding it back.
+Workaround: set `"network_profile": null` in `oalders-net.json` (where all outbound rules now live) and replace the curated bundle with an explicit `allow_domain` list (Anthropic, GitHub, npm, Go module proxy). The explicit `null` is the documented opt-out pattern — see nono's `docs/cli/clients/claude-code.mdx` (`claude-code-netopen` example). Today the parent `claude-code` profile doesn't set `network_profile`, so omitting the field would also work, but `null` is defensive against a future nono release adding it back.
 
 Upstream to watch:
 - https://github.com/always-further/nono/issues/793 — exec-sourced credentials (covers `apiKeyHelper` shape)
 - https://github.com/always-further/nono/issues/770 — refreshable credential backend
 - https://github.com/always-further/nono/issues/724 — 3rd-party provider profiles
 
-Re-test on each nono release: temporarily flip `"network_profile": null` to `"claude-code"` in `oalders.json` and run from `$TMPDIR`:
+Re-test on each nono release: temporarily flip `"network_profile": null` to `"claude-code"` in `oalders-net.json` and run from `$TMPDIR`:
 ```
 cd "${TMPDIR:-/tmp}" && nono run --profile oalders --allow-cwd -- curl -s -o /dev/null -w "%{http_code}\n" \
   -X POST "$ANTHROPIC_BASE_URL/v1/messages" -d '{}'
@@ -125,7 +143,7 @@ When claude or an MCP server can't reach something:
 1. Confirm the block: `nono why --path <path> --op read --profile oalders` (or `--host <hostname>` for network).
 2. Add the minimal grant to the right file:
    - **Stack-specific** (only useful in Perl/Node/Go/etc. projects) → the matching `oalders-<stack>.json` sibling. If the stack doesn't have a sibling yet, see "Language sibling profiles" above for how to add one.
-   - **Cross-cutting** (needed across all projects) → `oalders.json`.
+   - **Cross-cutting** (needed across all projects) → `oalders-core.json` (the net-free base). New network domains/ports → `oalders-net.json`.
 
    Grant kinds:
    - `filesystem.read` — read-only directories
@@ -137,9 +155,9 @@ When claude or an MCP server can't reach something:
 
 **Avoid broad allows on `~`, `~/.config`, `~/.local`, `~/.cache`** — they'll bring back the deny-overlap problem. Prefer specific subpaths.
 
-### Cross-cutting bits that stay in `oalders.json`
+### Cross-cutting bits that live in `oalders-core.json`
 
-These don't belong to any single tool or stack, so they live in the base:
+These don't belong to any single tool or stack, so they live in `oalders-core` (the net-free base that `oalders` always extends):
 
 - `read` on `~/.local/bin` (uvx wrapper, serena-mcp-server, generic user-installed scripts — used across siblings) and `~/.npm-packages` (npm-installed binaries: playwright-mcp consumer + standalone npx use).
 - `read` on `~/dot-files/bin` (npx wrapper that intercepts `@playwright/mcp@latest` so it sits ahead of `~/dot-files/node_modules/.bin/npx` in PATH).

--- a/nono/oalders-core.json
+++ b/nono/oalders-core.json
@@ -1,0 +1,53 @@
+{
+  "meta": {
+    "name": "oalders-core",
+    "description": "Net-free shared base: always-on MCP/runtime siblings, security policy, and cross-cutting filesystem grants. Holds no network rules so permissive profiles can compose it without inheriting an allowlist."
+  },
+  "extends": [
+    "claude-code",
+    "oalders-uv",
+    "oalders-serena",
+    "oalders-playwright",
+    "oalders-chrome"
+  ],
+  "security": {
+    "signal_mode": "allow_same_sandbox",
+    "process_info_mode": "allow_same_sandbox",
+    "ipc_mode": "full"
+  },
+  "filesystem": {
+    "read": [
+      "/usr/libexec/gcc",
+      "/usr/local/",
+      "~/.config/gh",
+      "~/.local/bin",
+      "~/.local/share/nvim/mason",
+      "~/.npm-packages",
+      "~/dot-files/bin",
+      "~/dot-files/gitignore_global",
+      "~/dot-files/node_modules",
+      "~/dot-files/nono",
+      "~/local/bin"
+    ],
+    "allow": [
+      "/tmp/claude-1000"
+    ],
+    "read_file": [
+      "/etc/bash.bashrc",
+      "/etc/gitconfig",
+      "~/.bashrc",
+      "~/.docker/config.json",
+      "~/.gitconfig",
+      "~/dot-files/bashrc",
+      "~/dot-files/claude/CLAUDE.md",
+      "~/dot-files/claude/statusline-command.sh"
+    ],
+    "allow_file": [
+      "~/.claude/.credentials.json"
+    ],
+    "bypass_protection": [
+      "~/.bashrc",
+      "~/dot-files/bashrc"
+    ]
+  }
+}

--- a/nono/oalders-net.json
+++ b/nono/oalders-net.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "name": "oalders-net",
+    "description": "All outbound network rules for the default oalders chain: curated allow_domain list, open_port, and the defensive network_profile:null opt-out. Includes uv's PyPI domains so the uv sibling can stay net-free."
+  },
+  "network": {
+    "network_profile": null,
+    "allow_domain": [
+      "*.anthropic.com",
+      "*.claude.ai",
+      "*.github.com",
+      "*.githubusercontent.com",
+      "api.anthropic.com",
+      "claude.ai",
+      "datatracker.ietf.org",
+      "files.pythonhosted.org",
+      "github.com",
+      "pypi.org",
+      "www.rfc-editor.org"
+    ],
+    "open_port": [80, 5000, 5001, 8080]
+  }
+}

--- a/nono/oalders-perl-net.json
+++ b/nono/oalders-perl-net.json
@@ -1,0 +1,18 @@
+{
+  "meta": {
+    "name": "oalders-perl-net",
+    "description": "CPAN/MetaCPAN/MagPie network access for Perl sessions, split out of oalders-perl so the filesystem grants can be reused net-free."
+  },
+  "network": {
+    "allow_domain": [
+      "*.cpan.org",
+      "*.cpantesters.org",
+      "*.metacpan.org",
+      "*.perl-magpie.org",
+      "cpan.org",
+      "cpanmetadb.plackperl.org",
+      "cpantesters.org",
+      "metacpan.org"
+    ]
+  }
+}

--- a/nono/oalders-perl-test.json
+++ b/nono/oalders-perl-test.json
@@ -1,0 +1,10 @@
+{
+  "meta": {
+    "name": "oalders-perl-test",
+    "description": "Opt-in permissive Perl test profile: open outbound network and unrestricted localhost ports for CPAN test suites (Test::TCP, live-network tests), with the same filesystem lockdown as oalders. Invoke via: nn --profile oalders-perl-test."
+  },
+  "extends": [
+    "oalders-core",
+    "oalders-perl"
+  ]
+}

--- a/nono/oalders-perl.json
+++ b/nono/oalders-perl.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "oalders-perl",
-    "description": "Perl development mixin: plenv, local::lib (~/perl5), Dist::Zilla, prove, MetaCPAN, perl-cpm, common rc files, system C headers for XS"
+    "description": "Perl development mixin (filesystem only): plenv, local::lib (~/perl5), Dist::Zilla, prove, perlimports, common rc files, system C headers for XS. Net-free; CPAN domains live in oalders-perl-net."
   },
   "filesystem": {
     "allow": [
@@ -26,18 +26,6 @@
       "~/dot-files/dataprinter",
       "~/dot-files/perlcriticrc",
       "~/dot-files/perlimports/perlimports.toml"
-    ]
-  },
-  "network": {
-    "allow_domain": [
-      "*.cpan.org",
-      "*.cpantesters.org",
-      "*.metacpan.org",
-      "*.perl-magpie.org",
-      "cpan.org",
-      "cpanmetadb.plackperl.org",
-      "cpantesters.org",
-      "metacpan.org"
     ]
   }
 }

--- a/nono/oalders-uv.json
+++ b/nono/oalders-uv.json
@@ -1,17 +1,11 @@
 {
   "meta": {
     "name": "oalders-uv",
-    "description": "uv runtime: location used by uv-installed tools (uvx, uv tool install), plus PyPI network access for installs"
+    "description": "uv runtime filesystem: location used by uv-installed tools (uvx, uv tool install). Net-free; PyPI domains live in oalders-net."
   },
   "filesystem": {
     "read": [
       "~/.local/share/uv"
-    ]
-  },
-  "network": {
-    "allow_domain": [
-      "pypi.org",
-      "files.pythonhosted.org"
     ]
   }
 }

--- a/nono/oalders.json
+++ b/nono/oalders.json
@@ -1,64 +1,6 @@
 {
   "extends": [
-    "claude-code",
-    "oalders-uv",
-    "oalders-serena",
-    "oalders-playwright",
-    "oalders-chrome"
-  ],
-  "security": {
-    "signal_mode": "allow_same_sandbox",
-    "process_info_mode": "allow_same_sandbox",
-    "ipc_mode": "full"
-  },
-  "filesystem": {
-    "read": [
-      "/usr/libexec/gcc",
-      "/usr/local/",
-      "~/.config/gh",
-      "~/.local/bin",
-      "~/.local/share/nvim/mason",
-      "~/.npm-packages",
-      "~/dot-files/bin",
-      "~/dot-files/gitignore_global",
-      "~/dot-files/node_modules",
-      "~/dot-files/nono",
-      "~/local/bin"
-    ],
-    "allow": [
-      "/tmp/claude-1000"
-    ],
-    "read_file": [
-      "/etc/bash.bashrc",
-      "/etc/gitconfig",
-      "~/.bashrc",
-      "~/.docker/config.json",
-      "~/.gitconfig",
-      "~/dot-files/bashrc",
-      "~/dot-files/claude/CLAUDE.md",
-      "~/dot-files/claude/statusline-command.sh"
-    ],
-    "allow_file": [
-      "~/.claude/.credentials.json"
-    ],
-    "bypass_protection": [
-      "~/.bashrc",
-      "~/dot-files/bashrc"
-    ]
-  },
-  "network": {
-    "network_profile": null,
-    "allow_domain": [
-      "*.anthropic.com",
-      "*.claude.ai",
-      "*.github.com",
-      "*.githubusercontent.com",
-      "api.anthropic.com",
-      "claude.ai",
-      "datatracker.ietf.org",
-      "github.com",
-      "www.rfc-editor.org"
-    ],
-    "open_port": [80, 5000, 5001, 8080]
-  }
+    "oalders-core",
+    "oalders-net"
+  ]
 }

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -270,3 +270,15 @@ setup() {
     # The one-shot marker is still consumed on the first launch.
     [ ! -f .tmp/fix-gh-issue.pending ]
 }
+
+@test "bin/nn auto-detect appends both oalders-perl and oalders-perl-net" {
+    # A cpanfile marks a Perl repo; detection must compose BOTH the fs mixin
+    # (oalders-perl) and the network mixin (oalders-perl-net). Appending only
+    # the fs half would silently strip CPAN network from auto-detected sessions.
+    echo "requires 'Moo';" > cpanfile
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f .nono/profile.json ]
+    grep -Fq '"oalders-perl"' .nono/profile.json
+    grep -Fq '"oalders-perl-net"' .nono/profile.json
+}


### PR DESCRIPTION
## Summary

Splits the monolithic `oalders` nono profile into composable building blocks and adds an opt-in, permissive profile for running Perl test suites under nono.

- **Profile decomposition**: `oalders.json` is recomposed from a net-free `oalders-core` base plus `oalders-net` (all outbound network rules). `oalders-perl` is split into a net-free filesystem profile plus `oalders-perl-net`.
- **New `oalders-perl-test` profile**: opt-in, permissive profile for Perl test suites. `bin/nn` appends both Perl mixins on auto-detect.
- **`oalders-uv` made net-free**: PyPI domains now live in `oalders-net`.
- **Installer**: symlinks the four new nono profiles; installs `docker-buildx-plugin` alongside Docker.
- **Docs/plans**: design doc and implementation plan for the permissive Perl-testing profile; `nono/CLAUDE.md` documents the core/net split.

## Test plan

- `test/nn.bats` verifies `nn` auto-detect appends both Perl mixins.
- Working tree clean; rebased onto latest `origin/main`.
