### PR TITLE
Add oalders-open nono profile for unrestricted outbound network

### DIFF
--- a/installer/symlinks.sh
+++ b/installer/symlinks.sh
@@ -102,6 +102,7 @@ ln -sf $prefix/nono/oalders-go.json ~/.config/nono/profiles/oalders-go.json
 ln -sf $prefix/nono/oalders-hugo.json ~/.config/nono/profiles/oalders-hugo.json
 ln -sf $prefix/nono/oalders-net.json ~/.config/nono/profiles/oalders-net.json
 ln -sf $prefix/nono/oalders-node.json ~/.config/nono/profiles/oalders-node.json
+ln -sf $prefix/nono/oalders-open.json ~/.config/nono/profiles/oalders-open.json
 ln -sf $prefix/nono/oalders-perl.json ~/.config/nono/profiles/oalders-perl.json
 ln -sf $prefix/nono/oalders-perl-net.json ~/.config/nono/profiles/oalders-perl-net.json
 ln -sf $prefix/nono/oalders-perl-test.json ~/.config/nono/profiles/oalders-perl-test.json

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -68,7 +68,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 | ------------------- | ------------------------------------------------------------------------------------- |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
 | `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
-| `oalders-open`      | Open outbound network (no `allow_domain` in its chain → `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |
+| `oalders-open`      | Open outbound network (no `allow_domain` in its chain, so `nono why` reports `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |
 
 Opt-in via per-repo `.nono/profile.json`:
 

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -67,7 +67,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 | Profile             | Owns                                                                                  |
 | ------------------- | ------------------------------------------------------------------------------------- |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
-| `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
+| `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain, so `nono why` likewise reports `network_allowed`), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
 | `oalders-open`      | Open outbound network (no `allow_domain` in its chain, so `nono why` reports `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |
 
 Opt-in via per-repo `.nono/profile.json`:

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -7,6 +7,7 @@ Wraps Claude Code in the [nono](https://nono.sh/) sandbox. Invoke via `nn` (from
 - `oalders.json` — nono profile composition root (`extends: [oalders-core, oalders-net]`), symlinked to `~/.config/nono/profiles/oalders.json`
 - `oalders-core.json` — net-free shared base (always-on MCP/runtime siblings, security policy, cross-cutting filesystem grants), symlinked to `~/.config/nono/profiles/oalders-core.json`
 - `oalders-net.json` — all outbound network rules for the default chain (curated `allow_domain`, `open_port`, `network_profile: null`), symlinked to `~/.config/nono/profiles/oalders-net.json`
+- `oalders-open.json` — permissive opt-in profile (`extends: [oalders-core]`, no `oalders-net`): full outbound network with the same filesystem lockdown as `oalders`, symlinked to `~/.config/nono/profiles/oalders-open.json`
 - `claude-settings.json` — `{"sandbox": {"enabled": false}}` passed to claude via `--settings`, symlinked to `~/.config/nono/claude-settings.json` (so claude's built-in sandbox stays off while nono does the real work)
 
 ## Per-project profiles
@@ -67,6 +68,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 | ------------------- | ------------------------------------------------------------------------------------- |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
 | `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
+| `oalders-open`      | Open outbound network (no `allow_domain` in its chain → `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |
 
 Opt-in via per-repo `.nono/profile.json`:
 
@@ -74,10 +76,11 @@ Opt-in via per-repo `.nono/profile.json`:
 {"extends": ["oalders", "oalders-terraform"]}
 ```
 
-`oalders-perl-test` is invoked directly rather than via a per-repo wrapper, because it intentionally drops the network/port restrictions a wrapper extending `oalders` would re-impose:
+`oalders-perl-test` and `oalders-open` are invoked directly rather than via a per-repo wrapper, because they intentionally drop the network/port restrictions a wrapper extending `oalders` would re-impose:
 
 ```
 nn --profile oalders-perl-test
+nn --profile oalders-open
 ```
 
 ### Adding a new sibling

--- a/nono/oalders-open.json
+++ b/nono/oalders-open.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "name": "oalders-open",
+    "description": "Permissive: full outbound network with the same filesystem lockdown as oalders. Composes oalders-core (the net-free shared base) without oalders-net, so no allow_domain filter is applied and all outbound is allowed. Invoke via: nn --profile oalders-open."
+  },
+  "extends": [
+    "oalders-core"
+  ]
+}


### PR DESCRIPTION
Closes #957

## Changes
- Add `nono/oalders-open.json` — an opt-in profile that composes the net-free base `oalders-core` *without* `oalders-net`. With no `allow_domain` entering the chain, nono leaves outbound fully open while the standard filesystem lockdown (inherited from `oalders-core`) stays intact. Mirrors the existing `oalders-perl-test` pattern, minus the Perl-specific grants.
- Wire the symlink in `installer/symlinks.sh` (alphabetically between `oalders-node` and `oalders-perl`).
- Document the profile in `nono/CLAUDE.md` (Files list, Opt-in only table, direct-invocation note).

Invoke via: `nn --profile oalders-open`

## Testing
- `nono policy validate nono/oalders-open.json` → valid
- `nono why --profile nono/oalders-open.json --host example.com` → `ALLOWED` (`Reason: network_allowed`)
- Filesystem lockdown preserved: `nono why ... --path ~/.ssh/id_rsa --op read` → `DENIED`
- `shfmt` clean on `installer/symlinks.sh`; `bin/test-nono-claude-md.sh` passes
- Code review (general + security) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)