### PR TITLE
Add merge-pr --close to tear down a branch without merging

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 usage() {
     cat <<'EOF'
-Usage: merge-pr [-f|--force] [gh pr merge args...]
+Usage: merge-pr [-f|--force] [--close] [gh pr merge/close args...]
 
 Merges the current branch's PR via `gh pr merge`, then removes the
 worktree, deletes the local branch, and kills the tmux session for the
@@ -14,6 +14,15 @@ Options:
   -f, --force   Discard uncommitted changes in the worktree when
                 removing it.
                 May appear anywhere in the argument list.
+  --close       Close the PR via `gh pr close` instead of merging it,
+                then run the same teardown (remove worktree, delete the
+                local branch, kill the tmux session). Because the branch
+                is being abandoned, this skips the unpushed-commits
+                pre-flight (cleanup discards local commits anyway) and
+                deletes the remote branch explicitly — a merge gets that
+                for free from GitHub's delete_branch_on_merge, but that
+                setting only fires on merge, not close. Extra args pass
+                through to `gh pr close`.
 
 Refuses:
   --auto, --auto-merge   gh pr merge would exit 0 while the PR stays
@@ -24,14 +33,19 @@ Refuses:
 EOF
 }
 
-# Parse our own --force/-f from anywhere in the argument list.
-# Refuse --auto / --auto-merge.
+# Parse our own --force/-f and --close from anywhere in the argument list.
+# Refuse --auto / --auto-merge. --close and -f/--force are consumed here and
+# must NOT be forwarded to gh; everything else passes through in gh_args.
 force=""
+close_mode=""
 gh_args=()
 for arg in "$@"; do
     case "$arg" in
         -f | --force)
             force="--force"
+            ;;
+        --close)
+            close_mode="1"
             ;;
         --auto | --auto-merge)
             echo "merge-pr: refusing $arg — cleanup would run before the merge completes" >&2
@@ -60,48 +74,55 @@ if [[ "$branch" == "HEAD" ]]; then
     exit 1
 fi
 
-# Pre-flight: branch must have an upstream.
-#
-# `@{u}` fails both when the branch is genuinely unpushed AND when it is
-# already on origin but its local tracking config is wrong (e.g.
-# branch.<name>.remote points at a clone URL instead of "origin"). In the
-# latter case "push first" misdiagnoses the problem — the branch is pushed;
-# only the tracking config needs repair. Distinguish the two by asking
-# origin directly.
-if ! git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    # Query the full ref path, not a bare name: `ls-remote origin foo`
-    # tail-matches path components and would also match `refs/heads/x/foo`,
-    # false-flagging a genuinely unpushed branch. The output is a single
-    # line, so `grep -q` consuming it before ls-remote blocks keeps the
-    # pipe safe under pipefail — don't widen this query.
-    if git ls-remote origin "refs/heads/$branch" 2>/dev/null | grep -q .; then
-        echo "merge-pr: branch '$branch' is on origin, but local tracking config" >&2
-        echo "          is wrong, so '@{u}' does not resolve. The branch is" >&2
-        echo "          already pushed — this is a config issue, not a missing push." >&2
-        printf "merge-pr: repair with 'git branch --set-upstream-to=origin/%s' and continue? [y/N] " "$branch" >&2
-        # Default to bailing: empty input (just Enter), EOF, or a
-        # non-interactive stdin all leave tracking untouched.
-        read -r reply || reply=""
-        case "$reply" in
-            [Yy]*)
-                git branch --set-upstream-to="origin/$branch" >&2
-                ;;
-            *)
-                echo "merge-pr: aborted — fix tracking config and re-run." >&2
-                exit 1
-                ;;
-        esac
-    else
-        echo "merge-pr: branch '$branch' has no upstream — push first" >&2
+# Close mode abandons the branch, so the "is it pushed / are there unpushed
+# commits?" pre-flight below is moot — cleanup discards local commits anyway,
+# and the branch need not be on origin at all. Skip the whole block (upstream
+# tracking AND unpushed-commit count) when closing; run it for merges, where
+# `gh pr merge` genuinely needs the branch pushed.
+if [[ -z "$close_mode" ]]; then
+    # Pre-flight: branch must have an upstream.
+    #
+    # `@{u}` fails both when the branch is genuinely unpushed AND when it is
+    # already on origin but its local tracking config is wrong (e.g.
+    # branch.<name>.remote points at a clone URL instead of "origin"). In the
+    # latter case "push first" misdiagnoses the problem — the branch is pushed;
+    # only the tracking config needs repair. Distinguish the two by asking
+    # origin directly.
+    if ! git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+        # Query the full ref path, not a bare name: `ls-remote origin foo`
+        # tail-matches path components and would also match `refs/heads/x/foo`,
+        # false-flagging a genuinely unpushed branch. The output is a single
+        # line, so `grep -q` consuming it before ls-remote blocks keeps the
+        # pipe safe under pipefail — don't widen this query.
+        if git ls-remote origin "refs/heads/$branch" 2>/dev/null | grep -q .; then
+            echo "merge-pr: branch '$branch' is on origin, but local tracking config" >&2
+            echo "          is wrong, so '@{u}' does not resolve. The branch is" >&2
+            echo "          already pushed — this is a config issue, not a missing push." >&2
+            printf "merge-pr: repair with 'git branch --set-upstream-to=origin/%s' and continue? [y/N] " "$branch" >&2
+            # Default to bailing: empty input (just Enter), EOF, or a
+            # non-interactive stdin all leave tracking untouched.
+            read -r reply || reply=""
+            case "$reply" in
+                [Yy]*)
+                    git branch --set-upstream-to="origin/$branch" >&2
+                    ;;
+                *)
+                    echo "merge-pr: aborted — fix tracking config and re-run." >&2
+                    exit 1
+                    ;;
+            esac
+        else
+            echo "merge-pr: branch '$branch' has no upstream — push first" >&2
+            exit 1
+        fi
+    fi
+
+    # Pre-flight: no unpushed commits.
+    unpushed=$(git rev-list --count '@{u}..HEAD')
+    if [[ "$unpushed" -ne 0 ]]; then
+        echo "merge-pr: branch '$branch' has $unpushed unpushed commit(s) — push first" >&2
         exit 1
     fi
-fi
-
-# Pre-flight: no unpushed commits.
-unpushed=$(git rev-list --count '@{u}..HEAD')
-if [[ "$unpushed" -ne 0 ]]; then
-    echo "merge-pr: branch '$branch' has $unpushed unpushed commit(s) — push first" >&2
-    exit 1
 fi
 
 # Pre-flight: refuse a dirty worktree *before* merging. This runs up front
@@ -155,19 +176,54 @@ elif command -v tmux >/dev/null 2>&1 && tmux list-panes -a >/dev/null 2>&1; then
     )
 fi
 
-# Dispatch on PR state.
+# Dispatch on PR state, mode-aware. An OPEN PR is acted on (merge or close);
+# a state that already matches our goal (MERGED for merge, CLOSED for close)
+# falls through to cleanup; the mismatched terminal state and anything else
+# is refused.
 case "$pr_state" in
     OPEN)
-        gh pr merge "${gh_args[@]}"
+        if [[ -n "$close_mode" ]]; then
+            gh pr close "${gh_args[@]}"
+        else
+            gh pr merge "${gh_args[@]}"
+        fi
         ;;
     MERGED)
+        if [[ -n "$close_mode" ]]; then
+            echo "merge-pr: refusing to close a MERGED PR" >&2
+            exit 1
+        fi
         echo "merge-pr: PR already MERGED — proceeding to cleanup"
+        ;;
+    CLOSED)
+        # Only meaningful in close mode; in merge mode this falls through to
+        # the `*` refusal below (preserving the existing message).
+        if [[ -n "$close_mode" ]]; then
+            echo "merge-pr: PR already CLOSED — proceeding to cleanup"
+        else
+            echo "merge-pr: refusing to act on PR in state '$pr_state'" >&2
+            exit 1
+        fi
         ;;
     *)
         echo "merge-pr: refusing to act on PR in state '$pr_state'" >&2
         exit 1
         ;;
 esac
+
+# Close mode only: delete the remote branch explicitly. A merge gets this for
+# free from GitHub's delete_branch_on_merge (see bin/gh-delete-branch-on-merge),
+# but that setting fires only on merge, not close — so an abandoned PR would
+# otherwise leave its branch stranded on origin. Tolerate failure: the branch
+# may already be gone, and that must not abort local teardown. Run here, while
+# cwd is still the worktree and before the tmux kill, to keep the "kill tmux
+# LAST" invariant. Covers both the OPEN-close and already-CLOSED paths.
+if [[ -n "$close_mode" ]]; then
+    if ! git push origin --delete "$branch"; then
+        echo "merge-pr: warning: could not delete remote branch 'origin/$branch'" >&2
+        echo "          (it may already be gone); continuing with local cleanup." >&2
+    fi
+fi
 
 # Cleanup. Order matters:
 #   1. cd out of the worktree before removing it.

--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -183,6 +183,9 @@ fi
 case "$pr_state" in
     OPEN)
         if [[ -n "$close_mode" ]]; then
+            # Like `gh pr merge`, this resolves the PR from the current
+            # branch's git context (implicit-branch detection); any extra
+            # positional/flag args pass through.
             gh pr close "${gh_args[@]}"
         else
             gh pr merge "${gh_args[@]}"
@@ -214,14 +217,21 @@ esac
 # Close mode only: delete the remote branch explicitly. A merge gets this for
 # free from GitHub's delete_branch_on_merge (see bin/gh-delete-branch-on-merge),
 # but that setting fires only on merge, not close — so an abandoned PR would
-# otherwise leave its branch stranded on origin. Tolerate failure: the branch
-# may already be gone, and that must not abort local teardown. Run here, while
-# cwd is still the worktree and before the tmux kill, to keep the "kill tmux
-# LAST" invariant. Covers both the OPEN-close and already-CLOSED paths.
+# otherwise leave its branch stranded on origin. Run here, while cwd is still
+# the worktree and before the tmux kill, to keep the "kill tmux LAST"
+# invariant. Covers both the OPEN-close and already-CLOSED paths.
 if [[ -n "$close_mode" ]]; then
-    if ! git push origin --delete "$branch"; then
-        echo "merge-pr: warning: could not delete remote branch 'origin/$branch'" >&2
-        echo "          (it may already be gone); continuing with local cleanup." >&2
+    # Only delete the remote branch if origin actually has it. Close mode
+    # tolerates a never-pushed or already-deleted branch (see the skipped
+    # upstream pre-flight above), so a missing remote ref is normal here,
+    # not an error worth warning about. ls-remote takes the full ref path
+    # to avoid the tail-match pitfall noted earlier in this script. Used as
+    # an `if` condition, `--exit-code`'s non-zero "ref absent" status is
+    # consumed by the `if` and never aborts the script under `set -e`.
+    if git ls-remote --exit-code origin "refs/heads/$branch" >/dev/null 2>&1; then
+        if ! git push origin --delete "$branch"; then
+            echo "merge-pr: warning: could not delete remote branch 'origin/$branch'; continuing with local cleanup." >&2
+        fi
     fi
 fi
 

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -305,3 +305,120 @@ esac
     [ "$status" -eq 0 ]
     [ ! -d "$WORKTREE_DIR" ]
 }
+
+# #950: --close tears down a PR without merging. The gh stub distinguishes
+# `pr view` (state lookup) from `pr close`/`pr merge`, recording a marker
+# file for whichever action runs. An OPEN PR must invoke `gh pr close`, never
+# `gh pr merge`, then run the full teardown including remote-branch deletion.
+@test "close: --close on an OPEN PR closes, cleans up, and deletes the remote branch" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+    # cwd was the now-removed worktree; ls-remote needs a valid cwd.
+    cd "$REPO_DIR"
+    run git ls-remote "$UPSTREAM_DIR" refs/heads/feature
+    [ -z "$output" ]
+}
+
+# An already-CLOSED PR skips the close call but still runs full teardown.
+@test "close: --close on a CLOSED PR skips close and still tears down" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "CLOSED\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ ! -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+    # cwd was the now-removed worktree; ls-remote needs a valid cwd.
+    cd "$REPO_DIR"
+    run git ls-remote "$UPSTREAM_DIR" refs/heads/feature
+    [ -z "$output" ]
+}
+
+# Close mode abandons the branch, so an unpushed commit must NOT bail the
+# pre-flight (contrast the merge-mode "unpushed commits" test above).
+@test "close: --close skips the unpushed-commit pre-flight" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    git -c commit.gpgsign=false commit -q --allow-empty -m "extra unpushed"
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+}
+
+# Closing a MERGED PR is nonsensical; refuse it.
+@test "close: --close on a MERGED PR refuses" {
+    _ready_repo
+    git checkout -q -b feature
+    git push -q -u origin feature
+    stub_command gh 'printf "MERGED\tmain\n"'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refusing to close a MERGED PR"* ]]
+}
+
+# Remote-branch deletion is tolerant: an already-gone branch still exits 0
+# and completes local cleanup. Delete origin/feature before running.
+@test "close: --close tolerates an already-deleted remote branch" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    git push -q origin --delete feature
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
+@test "close: usage mentions --close" {
+    run "$MERGE_PR" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--close"* ]]
+}

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -417,6 +417,39 @@ esac
     [ -z "$output" ]
 }
 
+# A branch that was NEVER pushed to origin must close and clean up silently:
+# close mode skips the upstream pre-flight, and the remote-branch deletion is
+# guarded by ls-remote, so the missing remote ref is normal — no warning.
+@test "close: --close on a never-pushed branch is silent about the remote branch" {
+    _ready_repo
+    # Build the worktree by hand (unlike setup_feature_worktree, which pushes):
+    # branch "feature" exists locally only, never on origin.
+    WORKTREE_DIR="$BATS_TEST_TMPDIR/feature-wt"
+    git worktree add -q "$WORKTREE_DIR" -b feature
+    cd "$WORKTREE_DIR"
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -d "$WORKTREE_DIR" ]
+    # The never-pushed path must not warn about a missing remote branch.
+    # Check $output here, before the branch-list `run` clobbers it.
+    [[ "$output" != *"could not delete remote branch"* ]]
+    [[ "$output" != *"warning"* ]]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
 @test "close: usage mentions --close" {
     run "$MERGE_PR" -h
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #950

## Changes
- Add a `--close` flag to `bin/merge-pr`. With `--close`, the script runs `gh pr close` instead of `gh pr merge`, then performs the same teardown (remove the worktree, delete the local branch, kill the tmux session).
- In close mode the unpushed-commits / upstream pre-flight is skipped, since the branch is being abandoned and cleanup discards local commits anyway. The dirty-worktree check (gated by `--force`) is retained.
- Close mode deletes the remote branch explicitly via `git push origin --delete`, guarded by `git ls-remote --exit-code` so it only runs when origin has the branch. A merge gets remote-branch deletion for free from GitHubs delete_branch_on_merge, but that setting only fires on merge, not close.
- Implemented as a flag on the existing script (per the issue) rather than a separate command, to keep all teardown logic in one place.

## Testing
- Added 7 bats tests in `test/merge-pr.bats` covering: OPEN close + remote delete, already-CLOSED, skipping the unpushed-commit pre-flight, refusing a MERGED PR, tolerating an already-deleted remote, the never-pushed silent path, and usage text.
- Full suite: 32/32 pass (`bats test/merge-pr.bats`).
- `precious lint bin/merge-pr` and `shellcheck bin/merge-pr` clean.
- Reviewed via general + security code review (two rounds); all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)