### PR TITLE
add-worktree: warn instead of exiting on label failures

### DIFF
--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -65,7 +65,20 @@ cd "$worktree_dir" || exit 1
 if [[ "$type" == "pr" ]]; then
     gh pr checkout "$number"
 elif [[ "$type" == "issue" ]]; then
-    gh issue edit "$number" --add-label "in progress"
+    # The "in progress" label may not exist in the repo yet. Try to create
+    # it first, then label the issue. Neither step should abort worktree
+    # setup: if we lack permission (or the label already exists, or the
+    # issue can't be found), warn and carry on.
+    # 2ECC40 is a traffic-light green.
+    if ! label_out=$(gh label create "in progress" --color 2ECC40 2>&1); then
+        case $label_out in
+            *already\ exists*) ;; # label is already there — nothing to do
+            *) echo "Warning: could not create 'in progress' label: $label_out" >&2 ;;
+        esac
+    fi
+    if ! gh issue edit "$number" --add-label "in progress"; then
+        echo "Warning: could not add 'in progress' label to issue #$number" >&2
+    fi
     # Queue the first `nn` launch in this worktree to auto-run
     # `/kitchen-sink:fix-gh-issue` (it infers issue #$number from the
     # fix-<n> branch name). bin/nn reads this marker, hands the line to

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -109,6 +109,55 @@ setup() {
     grep -Fxq '/kitchen-sink:fix-gh-issue' "$worktree/.tmp/fix-gh-issue.pending"
 }
 
+@test "add-worktree tries to create the in progress label for fix-<n> branches" {
+    setup_git_repo
+    export GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+    stub_command gh 'printf "%s\n" "$*" >>"$GH_LOG"
+exit 0'
+    run "$ADD_WORKTREE" fix-952
+    [ "$status" -eq 0 ]
+    # Created with a traffic-light green color.
+    grep -q "label create in progress --color 2ECC40" "$GH_LOG"
+}
+
+@test "add-worktree continues when gh issue edit fails to add the label" {
+    setup_git_repo
+    # Simulate the label add failing (e.g. label missing, or no perms). The
+    # script must warn and carry on, not abort worktree setup.
+    stub_command gh 'case "$*" in
+        "issue edit"*) echo "could not add label: not found" >&2; exit 1 ;;
+        *) exit 0 ;;
+    esac'
+    run "$ADD_WORKTREE" fix-952
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/fix-952"
+
+    [ -f "$worktree/.tmp/fix-gh-issue.pending" ]
+}
+
+@test "add-worktree continues when it lacks permission to create the label" {
+    setup_git_repo
+    # Simulate `gh label create` being denied (403). The script must warn
+    # and carry on to label the issue and finish setup.
+    stub_command gh 'case "$*" in
+        "label create"*) echo "HTTP 403: Resource not accessible by integration" >&2; exit 1 ;;
+        *) exit 0 ;;
+    esac'
+    run "$ADD_WORKTREE" fix-952
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/fix-952"
+
+    [ -f "$worktree/.tmp/fix-gh-issue.pending" ]
+}
+
 @test "add-worktree queues nothing for non-fix branches" {
     setup_git_repo
     run "$ADD_WORKTREE" feature-branch


### PR DESCRIPTION
## Summary
- `add-worktree` no longer aborts the whole worktree setup when the `gh` calls for the "in progress" label fail.
- It now tries to create the label first (traffic-light green, `2ECC40`), treating "already exists" as a no-op and warning on any other failure (e.g. lacking permission).
- It then adds the label to the issue, warning instead of exiting if that fails (label missing, issue not found, no perms).

Previously, under `set -e`, any `gh` failure killed the script before submodules, `npm i`, the tmux session, and the `fix-gh-issue` marker were set up.

## Test plan
- Added bats coverage: label-create attempt (with green color), continuing when `gh issue edit` fails, and continuing when label creation is denied (403).
- All 8 tests in `test/add-worktree.bats` pass; `precious lint bin/add-worktree` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)