### PR TITLE
nn: guard --profile overrides that cannot execute the claude binary

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -80,7 +80,7 @@ if [[ -n "$profile_override" ]]; then
     # message would. The check reads ~/.local/share/claude/... (neither cwd
     # nor $TMPDIR), so nono why's cwd/tmp false-verdict caveat doesn't apply.
     if claude_bin="$(command -v claude)"; then
-        claude_bin="$(readlink -f "$claude_bin")"
+        claude_bin="$(realpath "$claude_bin")"
         if nono why --path "$claude_bin" --op read --profile "$profile" 2>/dev/null | grep -q '^DENIED'; then
             echo "nn: profile '$profile' can't execute the claude binary (missing the claude-code base)." >&2
             echo "nn: it looks like a mixin meant to be composed via extends, not invoked directly." >&2

--- a/bin/nn
+++ b/bin/nn
@@ -66,6 +66,28 @@ if [[ -n "$profile_override" ]]; then
         profile="$profile_override"
     fi
     profile_label="$profile (--profile override)"
+
+    # A bare mixin override (oalders-perl, oalders-net, oalders-uv, ...) is a
+    # net-free filesystem sibling meant to be composed via `extends`, not
+    # invoked directly. It doesn't extend the claude-code base, so the sandbox
+    # never grants read+execute on the claude binary and the launch dies with
+    # a cryptic "/usr/bin/env: 'claude': Permission denied" (exit 126). Ask
+    # nono whether the resolved profile can actually read claude and refuse
+    # early with a useful message if it explicitly can't. Only an explicit
+    # DENIED verdict blocks: an unknown profile name (nono why exits non-zero,
+    # printing neither verdict) or any other nono-why error falls through to
+    # `nono run`, which reports those more accurately than a mixin-specific
+    # message would. The check reads ~/.local/share/claude/... (neither cwd
+    # nor $TMPDIR), so nono why's cwd/tmp false-verdict caveat doesn't apply.
+    if claude_bin="$(command -v claude)"; then
+        claude_bin="$(readlink -f "$claude_bin")"
+        if nono why --path "$claude_bin" --op read --profile "$profile" 2>/dev/null | grep -q '^DENIED'; then
+            echo "nn: profile '$profile' can't execute the claude binary (missing the claude-code base)." >&2
+            echo "nn: it looks like a mixin meant to be composed via extends, not invoked directly." >&2
+            echo "nn: run plain 'nn' to auto-compose, or use --profile oalders-perl-test for open-net Perl tests." >&2
+            exit 1
+        fi
+    fi
 fi
 
 dir="$PWD"

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -259,6 +259,44 @@ setup() {
     [ "$(grep -Fx -A1 -m1 -- '--read-file' "$BATS_TEST_TMPDIR/nono-argv" | tail -n1)" = "/usr/bin/env" ]
 }
 
+@test "bin/nn --profile refuses a mixin that can't execute the claude binary" {
+    # claude must resolve for the guard to run; stub it so the test doesn't
+    # depend on a real install. nono why reports the resolved profile can't
+    # read claude (the mixin footgun, #965), so the guard must refuse before
+    # ever reaching `nono run`.
+    stub_command claude 'true'
+    stub_command nono 'if [ "$1" = why ]; then echo DENIED; exit 0; fi; printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/nono-argv"'
+    run "$NN" --profile oalders-perl
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"can't execute the claude binary"* ]]
+    # Refused before launching: nono run was never reached, so no argv dump.
+    [ ! -f "$BATS_TEST_TMPDIR/nono-argv" ]
+}
+
+@test "bin/nn --profile proceeds when the profile can execute the claude binary" {
+    # An ALLOWED verdict means the override extends the claude-code base; the
+    # guard must let it through to nono run with the override profile intact.
+    stub_command claude 'true'
+    stub_command nono 'if [ "$1" = why ]; then echo ALLOWED; exit 0; fi; printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/nono-argv"'
+    run "$NN" --profile oalders
+    [ "$status" -eq 0 ]
+    [ "$(grep -Fx -A1 -m1 -- '--profile' "$BATS_TEST_TMPDIR/nono-argv" | tail -n1)" = "oalders" ]
+}
+
+@test "bin/nn --profile falls through to nono for an unknown profile name" {
+    # nono why exits non-zero for an unknown profile, printing neither verdict.
+    # The guard must NOT mistake that for a mixin: it falls through to nono
+    # run, which surfaces its own profile-not-found error rather than the
+    # misleading mixin warning. This is the deliberate divergence from #965's
+    # `! ALLOWED` proposal — refuse only on an explicit DENIED.
+    stub_command claude 'true'
+    stub_command nono 'if [ "$1" = why ]; then exit 1; fi; printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/nono-argv"'
+    run "$NN" --profile no-such-profile
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"can't execute the claude binary"* ]]
+    grep -Fxq -- "no-such-profile" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
 @test "bin/nn skips the queued prompt when the user supplies their own" {
     mkdir -p .tmp
     printf '%s\n' '/kitchen-sink:fix-gh-issue' >.tmp/fix-gh-issue.pending


### PR DESCRIPTION
Closes #965

## Problem

Invoking `nn --profile <mixin>` (e.g. `oalders-perl`, `oalders-net`, `oalders-uv`) fails with a cryptic error:

```
/usr/bin/env: 'claude': Permission denied
Permission denied (exit code 126).
```

`--profile` short-circuits discovery, so the bare mixin is used as-is. These net-free filesystem siblings are meant to be composed via `extends`, not invoked directly — they do not extend the claude-code base, so the sandbox never grants read+execute on the claude binary, and the launch dies before claude starts.

## Changes

- Added a guard to bin/nn`'s `--profile` override branch. Before launching, it asks `nono why --path <claude-binary> --op read --profile <name>` whether the resolved profile can read the claude binary, and refuses early with a clear, actionable message on an explicit DENIED verdict.
- Refuses **only** on an explicit DENIED. An unknown profile name (where `nono why` exits non-zero with no verdict) or any other `nono why` error falls through to `nono run`, which surfaces its own clearer error instead of a misleading mixin warning. This is a deliberate refinement of the issue's `! ALLOWED` proposal to avoid false "looks like a mixin" messages on typos.
- The guard is fail-safe: it only ever refuses or falls through, never adds a grant or weakens the sandbox. It is skipped entirely when claude is not on PATH.

## Testing

- Added 3 bats tests in test/nn.bats: refusal on DENIED (clear message, nono run never reached), proceed on ALLOWED, and fall-through on an unknown profile name.
- Full suite: 28/28 pass. precious lint clean.
- Red-green verified: the refusal test fails without the guard and passes with it.
- Verified end-to-end against the live nono: `nn --profile oalders-perl` and `nn --profile oalders-net` both exit 1 with the guidance message.

## Out of scope

The optional follow-up in the issue (tagging mixin `meta.description`s for discoverability) is not load-bearing once the guard exists and is left for a separate change.