### PR TITLE
merge-pr: do the right thing when run from the main working tree

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -143,8 +143,11 @@ fi
 worktree_path=$(git rev-parse --show-toplevel)
 git_common_dir=$(git rev-parse --git-common-dir)
 # In a linked worktree, --git-common-dir returns the main repo's .git;
-# its parent is the main repo working directory.
-main_repo=$(cd "$git_common_dir" && cd .. && pwd)
+# its parent is the main repo working directory. Resolve with `pwd -P`
+# (physical path) so it matches `--show-toplevel`, which is already
+# symlink-resolved — otherwise a cwd reached through a symlink would make
+# the two diverge and break the main-working-tree comparison below.
+main_repo=$(cd "$git_common_dir" && cd .. && pwd -P)
 
 # PR lookup: state + baseRefName in a single call.
 if ! pr_info=$(gh pr view --json state,baseRefName -q '[.state, .baseRefName] | @tsv' 2>/dev/null); then
@@ -233,6 +236,40 @@ if [[ -n "$close_mode" ]]; then
             echo "merge-pr: warning: could not delete remote branch 'origin/$branch'; continuing with local cleanup." >&2
         fi
     fi
+fi
+
+# Main-working-tree case. When merge-pr is run from the main checkout rather
+# than a linked worktree, worktree_path and main_repo resolve to the same
+# directory (--git-common-dir is the bare ".git", whose parent is the cwd).
+# git will never remove the main working tree, so the worktree-removal block
+# below would only emit a `fatal:` and a misleading "remove it manually" hint.
+# The process kill and tmux session kill also target a throwaway worktree —
+# here they'd act on the main checkout we're standing in (the proc kill would
+# even take out this very script). So skip that whole teardown: just switch
+# off the merged/closed branch and delete it, then report success.
+if [[ "$worktree_path" == "$main_repo" ]]; then
+    # git refuses to delete the branch currently checked out here, so switch
+    # to the PR's base first. If `gh pr merge -d` already switched away and
+    # deleted the branch, both steps are simply skipped (HEAD is no longer on
+    # "$branch", and the branch ref is gone).
+    #
+    # The switch can legitimately fail — e.g. the base has no local branch and
+    # no origin/<base> for git to DWIM from (shallow clone, base never
+    # fetched). Catch that instead of letting `set -e` abort with a bare git
+    # error: the PR is already merged/closed, so report clearly and leave the
+    # branch in place for the user to remove manually.
+    if [[ "$(git rev-parse --abbrev-ref HEAD)" == "$branch" ]]; then
+        if ! git switch "$pr_base"; then
+            echo "merge-pr: PR handled, but could not switch off '$branch' to base '$pr_base'." >&2
+            echo "          The local branch was left in place — switch away and delete it manually." >&2
+            exit 1
+        fi
+    fi
+    if git show-ref --verify --quiet "refs/heads/$branch"; then
+        git branch -D "$branch"
+    fi
+    echo "merge-pr: ran from the main working tree — no worktree to remove; cleanup done."
+    exit 0
 fi
 
 # Cleanup. Order matters:

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -450,6 +450,132 @@ esac
     [ -z "$output" ]
 }
 
+# #966: when merge-pr is run from the MAIN working tree (not a linked
+# worktree), it must still merge and clean up the branch, but skip the
+# worktree-removal step instead of emitting a `fatal:` + failure message.
+# Build the scenario by checking out "feature" directly in the main repo
+# (no `git worktree add`), so worktree_path == main_repo inside the script.
+@test "main tree: merges, deletes branch, switches to base, skips worktree removal" {
+    _ready_repo
+    # _ready_repo leaves cwd in REPO_DIR; make that explicit so the test runs
+    # from the main working tree (not a linked worktree) regardless of helper
+    # changes.
+    cd "$REPO_DIR"
+    git checkout -q -b feature
+    git push -q -u origin feature
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR"
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    # No worktree-removal attempt: no fatal, no failure message.
+    [[ "$output" != *"fatal"* ]]
+    [[ "$output" != *"failed to remove worktree"* ]]
+    [[ "$output" == *"main working tree"* ]]
+    # The main checkout still exists, the branch is gone, and HEAD is on base.
+    [ -d "$REPO_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+    run git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD
+    [[ "$output" == "main" ]]
+}
+
+# Main-tree + --close: closes the PR, deletes the remote branch, and cleans up
+# locally without attempting (and failing) to remove the main working tree.
+@test "main tree: --close cleans up and deletes the remote branch, no worktree removal" {
+    _ready_repo
+    cd "$REPO_DIR"
+    git checkout -q -b feature
+    git push -q -u origin feature
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) : >"$BATS_TEST_TMPDIR/close-was-called" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ -e "$BATS_TEST_TMPDIR/close-was-called" ]
+    [ ! -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    [[ "$output" != *"fatal"* ]]
+    [ -d "$REPO_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+    # cwd is still REPO_DIR (the main tree is never removed), so ls-remote
+    # against the upstream resolves fine without a cd.
+    run git ls-remote "$UPSTREAM_DIR" refs/heads/feature
+    [ -z "$output" ]
+}
+
+# The exact #966 scenario: `gh pr merge -d` already switched to base and
+# deleted the local branch before merge-pr's cleanup runs. The main-tree
+# path must tolerate the already-gone branch and still exit 0 cleanly.
+@test "main tree: tolerates a branch already switched-off and deleted by gh -d" {
+    _ready_repo
+    cd "$REPO_DIR"
+    git checkout -q -b feature
+    git push -q -u origin feature
+    unset TMUX
+    stub_command tmux 'exit 0'
+    # Mimic `gh pr merge -d`: on merge, switch to main and delete the branch,
+    # exactly as gh's --delete-branch would, before merge-pr cleans up.
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    merge) git switch -q main && git branch -D feature ;;
+esac
+'
+
+    run "$MERGE_PR"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"fatal"* ]]
+    [[ "$output" != *"failed to remove worktree"* ]]
+    [ -d "$REPO_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
+# Main tree, switch failure: if the PR base has no local branch and no
+# origin/<base> for git to DWIM from, the post-merge `git switch` fails. The
+# script must report it clearly and exit non-zero rather than aborting with a
+# bare git error — and must leave the (already-merged) branch in place.
+@test "main tree: reports cleanly when it cannot switch off the branch to the base" {
+    _ready_repo
+    cd "$REPO_DIR"
+    git checkout -q -b feature
+    git push -q -u origin feature
+    unset TMUX
+    stub_command tmux 'exit 0'
+    # Base "ghost" exists neither locally nor on origin, so `git switch ghost`
+    # cannot succeed.
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tghost\n" ;;
+    merge) : >"$BATS_TEST_TMPDIR/merge-was-called" ;;
+esac
+'
+
+    run "$MERGE_PR"
+    [ "$status" -eq 1 ]
+    [ -e "$BATS_TEST_TMPDIR/merge-was-called" ]
+    [[ "$output" == *"could not switch off 'feature' to base 'ghost'"* ]]
+    # The branch survives (left for manual cleanup); main tree intact.
+    [ -d "$REPO_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [[ "$output" == *"feature"* ]]
+}
+
 @test "close: usage mentions --close" {
     run "$MERGE_PR" -h
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #966

## Problem
`merge-pr` assumed it always runs inside a linked worktree. Run from the main checkout, the merge/branch-delete steps succeeded but the final `git worktree remove` failed with a `fatal:` (git never removes the main working tree), and the "remove it manually" hint it printed was wrong.

## Changes
- Detect the main-working-tree case by comparing the resolved worktree path to the main repo path. In that case, skip the worktree removal, the worktree process kill, and the tmux session kill; instead switch off the merged/closed branch to the PR base and delete the local branch, then exit cleanly.
- Resolve `main_repo` with `pwd -P` so it matches the symlink-resolved `--show-toplevel` (avoids a false negative when cwd is reached through a symlink).
- Catch a failing `git switch` (base branch absent locally with no `origin/<base>` to DWIM from) and report it clearly instead of aborting under `set -e`.

## Testing
- Added 4 bats tests (main-tree merge, `--close`, gh-already-deleted, and switch-failure paths).
- Red/green verified: the new main-tree tests fail without the fix and pass with it.
- Full suite green: `npx bats test/` -> 79/79 pass.
- `shellcheck bin/merge-pr` and `precious lint` clean.