### PR TITLE
nono: fix full Chrome crashpad crash + DevTools port under the sandbox

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -228,6 +228,37 @@ fi
 echo "🗯️nn: using profile $profile_label" >&2
 echo "🗯️nn: using settings $settings_label" >&2
 
+# superpowers-chrome MCP: make its full-Chrome DevTools endpoint usable under
+# the sandbox. Two sandbox-specific fixes, both gated on --chrome (#970):
+#
+#   1. Crashpad: full Chrome writes its crash database to
+#      ~/.config/google-chrome/Crash Reports (a fixed path, independent of
+#      --user-data-dir), which the claude-code base denies via
+#      deny_browser_data_linux. When it can't write there the crashpad handler
+#      aborts ("--database is required") and the browser SIGTRAPs on startup.
+#      oalders-chrome.json grants + bypass-protects exactly that subdir (the
+#      sensitive cookies/sessions under Default/ stay denied), but a grant
+#      can't create the dir (its parent stays denied), so pre-create it here,
+#      outside the sandbox, the same way .tmp/.serena-home are seeded above.
+#
+#   2. DevTools port: the MCP serves DevTools over a localhost TCP port
+#      (default range 9222-12111), but the default chain only opens
+#      80/5000/5001/8080, so the bind() fails ("Cannot start http server for
+#      devtools") and the MCP can't drive the browser. Pin the MCP to one
+#      fixed port via CHROME_WS_PORT and open just that port with --open-port
+#      (localhost connect + listen). Scoped to --chrome so other sandboxes
+#      keep the port closed.
+#
+# See nono/CLAUDE.md ("superpowers-chrome (full Chrome) under the sandbox").
+chrome_run_args=()
+chrome_env=()
+if ((chrome_enabled)); then
+    mkdir -p "$HOME/.config/google-chrome/Crash Reports"
+    chrome_devtools_port=9222
+    chrome_run_args=(--open-port "$chrome_devtools_port")
+    chrome_env=("CHROME_WS_PORT=$chrome_devtools_port")
+fi
+
 # Opt-in clodhopper wiring. clodhopper init --local writes the hooks into
 # .claude/settings.local.json (gitignored). --settings adds a settings source;
 # it doesn't replace the project hierarchy, so claude still loads
@@ -298,11 +329,12 @@ set -x
 # claude launches. Granting it here keeps the wrapper's own dependency out
 # of every override profile. Redundant grants are harmless.
 exec nono run --profile "$profile" --allow-cwd --workdir . \
-    --read-file /usr/bin/env "${extra_allow[@]}" -- \
+    --read-file /usr/bin/env "${chrome_run_args[@]+"${chrome_run_args[@]}"}" "${extra_allow[@]}" -- \
     env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 TMPDIR="$PWD/.tmp" \
     XDG_CACHE_HOME="$PWD/.tmp/cache" \
     NPM_CONFIG_CACHE="$PWD/.tmp/cache/npm" \
     SERENA_HOME="$PWD/.serena-home" \
     DISABLE_AUTOUPDATER=1 \
+    "${chrome_env[@]+"${chrome_env[@]}"}" \
     claude --settings "$session_settings" \
     --dangerously-skip-permissions "$@" "${auto_prompt[@]+"${auto_prompt[@]}"}"

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -42,7 +42,7 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 | `oalders-uv`        | `~/.local/share/uv` (uv runtime — used by `uvx` and `uv tool install`). Net-free; PyPI domains live in `oalders-net`. |
 | `oalders-serena`    | `~/.serena` (serena MCP config/logs/memories)                                          |
 | `oalders-playwright`| `~/.cache/ms-playwright` (Chromium bundle), `/dev/shm` (browser IPC). Net-free; the browser-download CDN hosts live in the paired `oalders-playwright-net` (composed into `oalders.json`'s `extends`, not `oalders-core`'s, so only the default chain gets them). |
-| `oalders-chrome`    | `/opt/google/chrome` (browser binary), `~/.cache/superpowers` (browser session dirs)   |
+| `oalders-chrome`    | `/opt/google/chrome` (browser binary), `~/.cache/superpowers` (browser session dirs), `~/.config/google-chrome/Crash Reports` (crashpad database — grant + `bypass_protection`; see "superpowers-chrome (full Chrome) under the sandbox") |
 
 ### Project-detected (mixed in by `nn`)
 
@@ -136,6 +136,27 @@ cd "${TMPDIR:-/tmp}" && nono run --profile oalders --allow-cwd -- curl -s -o /de
   -X POST "$ANTHROPIC_BASE_URL/v1/messages" -d '{}'
 ```
 Non-407 means the route became OAuth-aware and you can re-adopt the curated bundle. While `network_profile` is null, the `NO_PROXY` reset in `bin/nn` is vestigial (no proxy is started) but harmless — it re-becomes load-bearing the moment the curated bundle is restored.
+
+## superpowers-chrome (full Chrome) under the sandbox
+
+The `superpowers-chrome` MCP (opt-in via `nn --chrome`) drives the **full** Google Chrome build, not Playwright's headless shell. Two things break it under the sandbox; `bin/nn` and `oalders-chrome.json` fix both, gated on `--chrome` (#970).
+
+### 1. Crashpad crash database
+
+Full Chrome writes its crash database to **`~/.config/google-chrome/Crash Reports`** — a fixed path derived from the default config dir, *independent of `--user-data-dir`* (so pointing the session dir at `~/.cache/superpowers` doesn't move it). The base `claude-code` profile denies that tree via the `deny_browser_data_linux` group. When Chrome can't write there it launches its crashpad handler without a `--database` argument; the handler aborts with `chrome_crashpad_handler: --database is required` (plus `recvmsg: Connection reset by peer`), and the browser **SIGTRAPs on startup** (exit 133). The Playwright headless shell is immune because it ships no separate crashpad handler.
+
+The fix is narrow:
+
+- `oalders-chrome.json` grants **only** the `Crash Reports` subdir (`filesystem.allow`) and lifts the deny on it (`filesystem.bypass_protection`). nono rejects a `bypass_protection` path that has no matching grant, so the two must name the **same** path — you can't bypass the parent `~/.config/google-chrome` and allow only the child. Keeping the grant on the subdir leaves the sibling `Default/` (cookies, saved passwords, sessions) denied, which is the whole point of `deny_browser_data_linux`.
+- A grant can't *create* the dir (its parent stays denied), so `bin/nn` pre-creates `~/.config/google-chrome/Crash Reports` outside the sandbox before launch (same pattern as `.tmp`/`.serena-home`). Without the dir, Chrome can't establish the database and the crash returns.
+
+The crashpad-disabling flags the issue floated (`--disable-crashpad`, `--no-crashpad`, `--disable-crash-reporter`, `--disable-features=Crashpad`) do **not** prevent the handler from spawning on this Chrome build — confirmed by experiment — so disabling crashpad is not a viable alternative to the grant.
+
+### 2. DevTools TCP port
+
+The MCP serves the Chrome DevTools endpoint over a localhost TCP port (its default range is 9222–12111), but the default chain only opens `[80, 5000, 5001, 8080]` (`oalders-net`'s `open_port`). The `bind()` fails with `Cannot start http server for devtools` and the MCP can't drive the browser. (Playwright sidesteps this entirely by talking to the browser over a stdio pipe, not a TCP port — which is also why the headless shell "just works".)
+
+`bin/nn` pins the MCP to one fixed port via `CHROME_WS_PORT=9222` and opens exactly that port with `nono run --open-port 9222` (localhost connect + listen). Done via the CLI flag rather than a dedicated `*-net` sibling because nono's `extends` resolves by **name only** (not path), so a net sibling can't compose onto the path-based profiles `nn` builds (`.nono/profile.json` wrappers, `--profile` overrides); the flag is conditional by construction and works for every profile shape. Scoped to `--chrome` so idle and non-browser sandboxes keep the port closed.
 
 ## Kernel requirement
 

--- a/nono/oalders-chrome.json
+++ b/nono/oalders-chrome.json
@@ -1,14 +1,18 @@
 {
   "meta": {
     "name": "oalders-chrome",
-    "description": "superpowers-chrome MCP: Chrome browser binary and session cache"
+    "description": "superpowers-chrome MCP: Chrome browser binary, session cache, and crashpad database (so full Chrome doesn't SIGTRAP on startup under the sandbox)"
   },
   "filesystem": {
     "read": [
       "/opt/google/chrome"
     ],
     "allow": [
-      "~/.cache/superpowers"
+      "~/.cache/superpowers",
+      "~/.config/google-chrome/Crash Reports"
+    ],
+    "bypass_protection": [
+      "~/.config/google-chrome/Crash Reports"
     ]
   }
 }

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -320,3 +320,41 @@ setup() {
     grep -Fq '"oalders-perl"' .nono/profile.json
     grep -Fq '"oalders-perl-net"' .nono/profile.json
 }
+
+@test "bin/nn --chrome opens the pinned DevTools port and sets CHROME_WS_PORT" {
+    # The superpowers-chrome MCP serves DevTools over a localhost TCP port the
+    # default chain doesn't open. nn opens one fixed port (--open-port) and
+    # pins the MCP to it (CHROME_WS_PORT) so the bind lands on the opened port
+    # instead of a random one in the MCP's 9222-12111 range (#970).
+    run "$NN" --chrome
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "9222" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "CHROME_WS_PORT=9222" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn --chrome pre-creates the crashpad Crash Reports dir" {
+    # The oalders-chrome grant can't create the dir (its parent stays denied),
+    # so nn seeds it outside the sandbox; without it full Chrome SIGTRAPs on
+    # startup in the crashpad handler (#970).
+    run "$NN" --chrome
+    [ "$status" -eq 0 ]
+    [ -d "$HOME/.config/google-chrome/Crash Reports" ]
+}
+
+@test "bin/nn without --chrome opens no DevTools port" {
+    # The port and env pin stay scoped to --chrome sessions; opening the port
+    # for every sandbox would needlessly widen idle and non-browser sessions.
+    run "$NN"
+    [ "$status" -eq 0 ]
+    ! grep -Fxq -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv"
+    ! grep -Fxq -- "CHROME_WS_PORT=9222" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn --chrome is consumed, not forwarded to claude" {
+    # --chrome is an nn-specific flag: it must be parsed out of \$@, not passed
+    # through to claude (which would reject the unknown flag).
+    run "$NN" --chrome
+    [ "$status" -eq 0 ]
+    ! grep -Fxq -- "--chrome" "$BATS_TEST_TMPDIR/nono-argv"
+}

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -347,6 +347,9 @@ setup() {
     # for every sandbox would needlessly widen idle and non-browser sessions.
     run "$NN"
     [ "$status" -eq 0 ]
+    # Guard against a vacuous pass: if the stub never wrote the argv dump the
+    # negative greps would "succeed" on a missing file and mask a regression.
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
     ! grep -Fxq -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv"
     ! grep -Fxq -- "CHROME_WS_PORT=9222" "$BATS_TEST_TMPDIR/nono-argv"
 }
@@ -356,5 +359,6 @@ setup() {
     # through to claude (which would reject the unknown flag).
     run "$NN" --chrome
     [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
     ! grep -Fxq -- "--chrome" "$BATS_TEST_TMPDIR/nono-argv"
 }

--- a/test/nono-profiles.bats
+++ b/test/nono-profiles.bats
@@ -56,3 +56,48 @@ SYMLINKS="$SCRIPT_DIR/installer/symlinks.sh"
         }
     done
 }
+
+# Full Chrome writes its crash database to ~/.config/google-chrome/Crash
+# Reports (a fixed path, not under --user-data-dir), which the claude-code
+# base denies via deny_browser_data_linux. Without a writable crash dir the
+# crashpad handler aborts ("--database is required") and the browser SIGTRAPs
+# on startup under the sandbox (#970). The fix grants that subdir AND
+# bypass-protects it — nono rejects a bypass_protection path that lacks a
+# matching grant, so the two must travel together.
+@test "oalders-chrome.json grants the crashpad Crash Reports dir" {
+    run grep -Fq '"~/.config/google-chrome/Crash Reports"' "$NONO_DIR/oalders-chrome.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "oalders-chrome.json bypass-protects the Crash Reports dir it grants" {
+    # nono: bypass_protection only removes the deny; it must be paired with an
+    # allow/read/write grant for the same path or the sandbox refuses to start.
+    run jq -e '
+        (.filesystem.bypass_protection // []) as $b
+        | (.filesystem.allow // []) as $a
+        | ($b | index("~/.config/google-chrome/Crash Reports")) != null
+          and ($a | index("~/.config/google-chrome/Crash Reports")) != null
+    ' "$NONO_DIR/oalders-chrome.json"
+    [ "$status" -eq 0 ]
+}
+
+# The grant must stay scoped to the Crash Reports subdir. Granting the parent
+# ~/.config/google-chrome (or bypassing it) would expose the sibling Default/
+# dir, where cookies, saved passwords, and sessions live — exactly what
+# deny_browser_data_linux protects.
+@test "oalders-chrome.json does not grant the whole google-chrome data dir" {
+    run jq -e '
+        [.filesystem.allow[]?, .filesystem.read[]?, .filesystem.bypass_protection[]?]
+        | any(. == "~/.config/google-chrome" or . == "~/.config/google-chrome/")
+    ' "$NONO_DIR/oalders-chrome.json"
+    # jq -e exits non-zero when the result is false/null: that is the pass.
+    [ "$status" -ne 0 ]
+}
+
+# oalders-chrome is composed into oalders-core, which the permissive
+# open-network profiles also extend — so it must stay net-free (no network
+# rules), the same invariant the playwright sibling holds (#969).
+@test "oalders-chrome.json carries no network rules (stays net-free)" {
+    run grep -Fq '"network"' "$NONO_DIR/oalders-chrome.json"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #970

## Problem

Full Google Chrome (the `superpowers-chrome` MCP, opt-in via `nn --chrome`) crashed on startup under the nono sandbox in its crashpad handler:

```
chrome_crashpad_handler: --database is required
ERROR ... recvmsg: Connection reset by peer (104)
<process exited: signal=SIGTRAP>
```

The Playwright headless shell was unaffected, so the bug was specific to the full browser under the sandbox.

## Root cause (verified outside the sandbox)

Comparing the crashpad handler's argv inside vs. outside the sandbox:

- **Outside:** Chrome passes `--database=~/.config/google-chrome/Crash Reports` and the handler runs.
- **Inside:** that path (a fixed location, *independent of* `--user-data-dir`) is denied by the base profile's `deny_browser_data_linux` group, so Chrome launches the handler with no `--database`, the handler aborts, and the browser SIGTRAPs.

A second, independent blocker surfaced once the crash was fixed: the MCP serves DevTools over a localhost TCP port (default range 9222–12111), but the default chain only opens `80/5000/5001/8080`, so the bind fails with `Cannot start http server for devtools`. (Playwright sidesteps this by using a stdio pipe, not TCP — which is why the headless shell "just worked".)

The crashpad-disabling flags the issue floated (`--disable-crashpad`, `--no-crashpad`, `--disable-crash-reporter`, `--disable-features=Crashpad`) do **not** stop the handler from spawning on this Chrome build — confirmed by experiment.

## Changes

- **`nono/oalders-chrome.json`** — grant + `bypass_protection` on **only** `~/.config/google-chrome/Crash Reports`. The sensitive sibling `Default/` (cookies, passwords, sessions) stays denied. nono requires a `bypass_protection` path to be paired with a grant for the same path, so the parent can't be used.
- **`bin/nn`** (gated on `--chrome`) — pre-create the crash dir outside the sandbox (a grant can't create it; its parent stays denied), pin the MCP to `CHROME_WS_PORT=9222`, and pass `nono run --open-port 9222`. A CLI flag rather than a `*-net` sibling because nono's `extends` resolves by name only and can't compose onto the path-based profiles `nn` builds.
- **`nono/CLAUDE.md`** — new section documenting both fixes and why the flag approach was used.
- **`test/nn.bats`, `test/nono-profiles.bats`** — tests for grant scoping, the net-free invariant, port pinning, dir pre-creation, and that non-`--chrome` sessions keep the port closed.

## Testing

- `npm test` (bats): 94/94 pass, 0 failures.
- `precious lint`: clean.
- End-to-end under real `nono run` (outside the sandbox): full Chrome launches with **0 crashpad errors**, DevTools responds on the pinned port (`Chrome/148.0.7778.96`), and `Default/Cookies` remains DENIED after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
