### PR TITLE
Add opt-in oalders-ansible nono profile for the pipx ansible venv

### DIFF
--- a/installer/symlinks.sh
+++ b/installer/symlinks.sh
@@ -96,6 +96,7 @@ ln -sf $prefix/oh-my-posh/themes/local.omp.json ~/.config/oh-my-posh/themes/loca
 ln -sf $prefix/claude-pulse/config.json ~/.config/claude-pulse/config.json
 ln -sf $prefix/mcphub/servers.json ~/.config/mcphub/servers.json
 ln -sf $prefix/nix/nix.conf ~/.config/nix/nix.conf
+ln -sf $prefix/nono/oalders-ansible.json ~/.config/nono/profiles/oalders-ansible.json
 ln -sf $prefix/nono/oalders-chrome.json ~/.config/nono/profiles/oalders-chrome.json
 ln -sf $prefix/nono/oalders-core.json ~/.config/nono/profiles/oalders-core.json
 ln -sf $prefix/nono/oalders-go.json ~/.config/nono/profiles/oalders-go.json

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -68,6 +68,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 
 | Profile             | Owns                                                                                  |
 | ------------------- | ------------------------------------------------------------------------------------- |
+| `oalders-ansible`   | `~/.local/share/pipx/venvs/ansible` (read+exec; the pipx venv whose binaries `~/.local/bin/ansible*` symlink into). Filesystem only, no network — SSH egress to deploy targets stays out of scope. Opt-in because ansible is deploy-host tooling rarely used inside dev repos. |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
 | `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain, so `nono why` likewise reports `network_allowed`), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
 | `oalders-open`      | Open outbound network (no `allow_domain` in its chain, so `nono why` reports `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -68,7 +68,7 @@ These siblings are symlinked into `~/.config/nono/profiles/` but aren't mixed in
 
 | Profile             | Owns                                                                                  |
 | ------------------- | ------------------------------------------------------------------------------------- |
-| `oalders-ansible`   | `~/.local/share/pipx/venvs/ansible` (read+exec; the pipx venv whose binaries `~/.local/bin/ansible*` symlink into). Filesystem only, no network — SSH egress to deploy targets stays out of scope. Opt-in because ansible is deploy-host tooling rarely used inside dev repos. |
+| `oalders-ansible`   | `~/.local/share/pipx/venvs/ansible` (read; the pipx venv whose binaries `~/.local/bin/ansible*` symlink into — the read grant is what lets them run). Filesystem only, no network — SSH egress to deploy targets stays out of scope. Opt-in because ansible is deploy-host tooling rarely used inside dev repos. |
 | `oalders-terraform` | `~/.terraform.d`, `~/.terraformrc` (read-only); `registry.terraform.io` (network)     |
 | `oalders-perl-test` | Open outbound network + unrestricted localhost ports (no `allow_domain`/`open_port` in its chain, so `nono why` likewise reports `network_allowed`), with `oalders-core` + `oalders-perl` grants and the full filesystem lockdown. For CPAN test suites needing live network or `Test::TCP`-style ephemeral ports. |
 | `oalders-open`      | Open outbound network (no `allow_domain` in its chain, so `nono why` reports `network_allowed`), with only `oalders-core` grants and the full filesystem lockdown. General-purpose permissive profile for non-Perl sessions that genuinely need unrestricted outbound. |
@@ -173,7 +173,7 @@ When claude or an MCP server can't reach something:
    - **Cross-cutting** (needed across all projects) → `oalders-core.json` (the net-free base). New network domains/ports → `oalders-net.json`.
 
    Grant kinds:
-   - `filesystem.read` — read-only directories
+   - `filesystem.read` — read-only directories (also lets binaries inside run: nono models only read/write, with no separate exec right, so the read grant is what makes a tool's venv/bin dir executable)
    - `filesystem.allow` — read+write directories
    - `filesystem.read_file` / `allow_file` — single files
    - `network.allow_domain` — HTTPS hosts (wildcards like `*.github.com` OK)

--- a/nono/oalders-ansible.json
+++ b/nono/oalders-ansible.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "name": "oalders-ansible",
+    "description": "Ansible CLI mixin: read+execute the pipx-installed ansible venv so ansible-vault / ansible-playbook can run. Filesystem only; no network egress."
+  },
+  "filesystem": {
+    "read": [
+      "~/.local/share/pipx/venvs/ansible"
+    ]
+  }
+}

--- a/nono/oalders-ansible.json
+++ b/nono/oalders-ansible.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "oalders-ansible",
-    "description": "Ansible CLI mixin: read+execute the pipx-installed ansible venv so ansible-vault / ansible-playbook can run. Filesystem only; no network egress."
+    "description": "Ansible CLI mixin: read the pipx-installed ansible venv so its binaries (ansible-vault / ansible-playbook) can run. Filesystem only; no network egress."
   },
   "filesystem": {
     "read": [


### PR DESCRIPTION
Closes #973

## Changes
- Add opt-in nono profile `nono/oalders-ansible.json` granting read on the pipx ansible venv (`~/.local/share/pipx/venvs/ansible`) so `ansible-vault` / `ansible-playbook` can run under the sandbox. Filesystem only, no network egress.
- Register its symlink in `installer/symlinks.sh` (alphabetical placement).
- Document it under "Opt-in only" in `nono/CLAUDE.md`, mirroring the existing `oalders-terraform` pattern, plus a note on the `filesystem.read` grant-kind clarifying that nono models only read/write (no separate exec op) — the read grant is what lets a tool's venv binaries run.

Opt-in (symlinked, not auto-composed into the default chain), since ansible is deploy-host tooling rarely used inside dev repos. Activate via `nn --profile oalders-ansible` or a per-repo `.nono/profile.json` (`{"extends": ["oalders", "oalders-ansible"]}`).

## Testing
- `nono profile validate` -> valid.
- `nono why`: the `ansible-vault` / `ansible-playbook` paths are now ALLOWED under `oalders-ansible`, and still DENIED (the issue's `path_not_granted`) under the baseline `oalders`.
- The venv interpreter resolves to `/usr/bin/python3.12`, already covered by the base profile's `system_read_linux_core` group -- so the single read grant is sufficient and minimal.
- `shfmt` clean on `installer/symlinks.sh`.
- Code review (general + security lenses) clean.
