### PR TITLE
remove-worktree: --force teardown of submodule worktrees (#977)

### DIFF
--- a/bin/remove-worktree
+++ b/bin/remove-worktree
@@ -50,5 +50,14 @@ else
     echo "remove-worktree: warning: kill-worktree-procs not found; skipping process cleanup" >&2
 fi
 
-git worktree remove "$@" "$worktree_path"
+# git refuses to remove a worktree containing an initialized submodule unless
+# --force is given (issue #977). Escalate to --force when .gitmodules is
+# present, matching bin/merge-pr. This is already an aggressive teardown tool —
+# it kills process trees and force-deletes the branch below — so discarding a
+# submodule checkout here is in keeping.
+if [ -f "$worktree_path/.gitmodules" ]; then
+    git worktree remove --force "$@" "$worktree_path"
+else
+    git worktree remove "$@" "$worktree_path"
+fi
 git branch -D "$@" "$branch_name"

--- a/test/remove-worktree.bats
+++ b/test/remove-worktree.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load 'helpers.bash'
+
+setup() {
+    setup_sandbox
+    REMOVE_WORKTREE="$BIN_DIR/remove-worktree"
+    # No tmux: stub pgrep so the tmux-session-kill block is skipped (an empty
+    # `$(pgrep tmux)` short-circuits it). Mirrors add-worktree.bats.
+    stub_command pgrep 'exit 1'
+    export GIT_CEILING_DIRECTORIES
+    GIT_CEILING_DIRECTORIES="$(dirname "$BATS_TEST_TMPDIR")"
+}
+
+@test "remove-worktree prints usage with no args" {
+    run "$REMOVE_WORKTREE"
+    [[ "$output" == *"Usage: remove-worktree"* ]]
+}
+
+# Baseline: a plain worktree (no submodule) is removed without -f.
+@test "remove-worktree removes a clean worktree without submodules" {
+    setup_git_repo
+    setup_upstream
+    setup_feature_worktree
+    # Run from the main repo, as a user would.
+    cd "$REPO_DIR"
+
+    run "$REMOVE_WORKTREE" feature
+    [ "$status" -eq 0 ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}
+
+# #977: a worktree containing an initialized submodule must be removed
+# without the user passing -f. remove-worktree escalates to --force
+# internally when .gitmodules is present; without that handling git refuses
+# to remove a worktree with an active submodule and this fails.
+@test "remove-worktree removes a worktree with a submodule without -f" {
+    setup_git_repo
+    setup_upstream
+    setup_feature_worktree --with-submodule
+    cd "$REPO_DIR"
+
+    run "$REMOVE_WORKTREE" feature
+    [ "$status" -eq 0 ]
+    [ ! -d "$WORKTREE_DIR" ]
+    run git -C "$REPO_DIR" branch --list feature
+    [ -z "$output" ]
+}


### PR DESCRIPTION
Closes #977

## Problem

`git worktree remove` refuses a worktree that contains an initialized
submodule unless `--force` is given. `bin/merge-pr` already escalates to a
single `--force` when `.gitmodules` is present, but `bin/remove-worktree` had
no such handling — so `remove-worktree <branch>` on a submodule worktree
failed outright unless the user remembered to pass `-f`.

## Changes

- `bin/remove-worktree`: escalate `git worktree remove` to `--force` when the
  worktree contains a `.gitmodules`, mirroring the existing `bin/merge-pr`
  convention.
- `test/remove-worktree.bats`: new suite (none existed). Covers the usage
  message, plain-worktree removal, and submodule-worktree removal without `-f`.

## Note on the issue's proposed approach

The issue proposed running `git submodule deinit` to allow a *forceless*
removal. I verified empirically on git 2.43 that this premise does not hold:
git's `validate_no_submodules` check refuses a forceless removal regardless of
whether the submodule is deinit'd, and a single `--force` already removes a
submodule worktree (clean or dirty). So no `deinit` step is added — the change
is the minimal `--force` escalation that actually works. `bin/merge-pr`
already handled this and needed no change.

## Testing

- Full BATS suite: 98 passing, 0 failing (`npm test`).
- Red-green verified: the submodule-removal test fails when the `--force`
  escalation is reverted, and passes with it restored.
- `precious lint` clean on the changed files.
