### PR TITLE
Document read-only Playwright cache behavior in global CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,6 +1,25 @@
-# Temp files
+# Global instructions
+
+## Temp files
 
 When creating temporary files or directories, default to `$TMPDIR` if it is set
 in the environment, falling back to `/tmp` only when it is unset. Do not
 hardcode `/tmp`. This applies to `mktemp`, scratch files, test fixtures, and
 anything else that lands in a temp location.
+
+## Playwright browser cache is read-only in the nono sandbox
+
+`~/.cache/ms-playwright` is mounted **read-only** inside the nono sandbox on
+purpose: it is a single host browser bundle shared across every worktree and
+the Playwright MCP, so sessions may execute the browsers but must never write
+them (writes would poison the bundle for the host and for other sessions).
+
+If a sandboxed Playwright run fails with a write/permission error on
+`~/.cache/ms-playwright` (typically during `playwright install` or a browser
+download), do **not** try to work around it — not with `nono run --allow`, not
+by editing the nono profile to make the path writable. The error means the host
+bundle is missing the browser build this run needs (usually a Playwright
+version bump). The fix runs on the host, **outside** the sandbox: tell the user
+to run `installer/playwright-mcp.sh` (it runs `npx playwright install`) to
+refresh the bundle, then re-run. Normal test runs against an already-seeded
+browser work read-only and need no change.


### PR DESCRIPTION
Closes #979

## Context

#979 proposed making `~/.cache/ms-playwright` writable in the nono profile so
Playwright works under the sandbox. Investigation showed that's the wrong fix:

- Running tests against the **seeded, version-matched** browser already works
  **read-only** under the sandbox (reproduced: launched headless Chromium,
  rendered a page, zero writes to the cache).
- Playwright only writes to that dir during `install()` — and it needs the
  **whole** dir writable (lockfile, `.links`, *and* the browser binary
  download), so there is no narrow subpath carve-out that yields a working
  install.
- The read-only mount is deliberate (#976): one host bundle shared across
  worktrees and the Playwright MCP, kept read-only so no session can poison it.
  A blocked write is the intended "reseed the host bundle" signal.

So #979 is works-as-designed for runs; the real gap was **ergonomics** — the
raw `Permission denied` looks like a sandbox bug rather than "reseed on host."

## Changes

- Add a Playwright section to the global `claude/CLAUDE.md` so any sandboxed
  agent recognizes a read-only `~/.cache/ms-playwright` write error and
  surfaces the host-side reseed (`installer/playwright-mcp.sh`) instead of
  attempting `--allow` / writable-profile workarounds.
- Restructure the file under a single `# Global instructions` H1 with `##`
  sections (matches the repo's root `CLAUDE.md`, fixes markdownlint MD025).

## Testing

- Doc-only change; `markdownlint-cli claude/CLAUDE.md` exits 0.
- Claims verified by live repro inside the sandbox: read-only launch succeeds;
  `install()`'s three writes (`__dirlock`, `.links/<sha>`, `chromium-*`) are
  each blocked read-only.
