### PR TITLE
Fix merge-pr --close: pass branch explicitly to gh pr close

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -242,10 +242,11 @@ if [[ -z "$no_pr" ]]; then
     case "$pr_state" in
         OPEN)
             if [[ -n "$close_mode" ]]; then
-                # Like `gh pr merge`, this resolves the PR from the current
-                # branch's git context (implicit-branch detection); any extra
-                # positional/flag args pass through.
-                gh pr close "${gh_args[@]}"
+                # Unlike `gh pr merge`, `gh pr close` has no implicit
+                # current-branch detection — its positional PR arg is
+                # required — so pass "$branch" explicitly. Any extra
+                # positional/flag args still pass through after it.
+                gh pr close "$branch" "${gh_args[@]}"
             else
                 gh pr merge "${gh_args[@]}"
             fi

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -361,6 +361,27 @@ esac
     [ -z "$output" ]
 }
 
+# #982: `gh pr close` has no implicit current-branch detection (its positional
+# PR arg is required), so a bare `merge-pr --close` must pass the branch name
+# explicitly. Without it, `gh pr close` errors and teardown never runs. The
+# stub records its positional arg ($3, after `pr close`) so we can assert it.
+@test "close: --close passes the branch name to gh pr close" {
+    _ready_repo
+    setup_feature_worktree
+    unset TMUX
+    stub_command tmux 'exit 0'
+    stub_command gh '
+case "$2" in
+    view) printf "OPEN\tmain\n" ;;
+    close) printf "%s" "$3" >"$BATS_TEST_TMPDIR/close-arg" ;;
+esac
+'
+
+    run "$MERGE_PR" --close
+    [ "$status" -eq 0 ]
+    [ "$(cat "$BATS_TEST_TMPDIR/close-arg")" = "feature" ]
+}
+
 # An already-CLOSED PR skips the close call but still runs full teardown.
 @test "close: --close on a CLOSED PR skips close and still tears down" {
     _ready_repo


### PR DESCRIPTION
Closes #982

## Problem
A bare `merge-pr --close` aborted before teardown: it ran `gh pr close "${gh_args[@]}"` with an empty array, and `gh pr close` (unlike `gh pr merge`) has no implicit current-branch detection — its positional PR arg is required. The error meant the worktree/branch/tmux teardown never ran.

## Changes
- `bin/merge-pr`: pass the already-captured `"$branch"` to `gh pr close`, and correct the adjacent comment that wrongly claimed implicit-branch detection.
- `test/merge-pr.bats`: regression test asserting the branch name reaches `gh pr close`.

## Testing
- Full bats suite: 40/40 pass.
- Red-green verified: the new test fails without the fix and passes with it.
- `precious lint` clean.