### PR TITLE
nn: serve Hugo over the tailscale IP when the host has one

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -55,6 +55,40 @@ profile=""
 profile_label=""
 project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
 
+# Hugo detection, computed once and reused. Markers: modern config names
+# (hugo.toml/yaml/json), the modular config/_default/ layout, OR legacy
+# config.toml paired with themes/. The bare hugo.* names and config/_default/
+# are Hugo-specific and need no themes/ guard; only config.toml does (it
+# guards against false positives on any other TOML-using project). Detected
+# here (not just in the mixin auto-gen block below) so it also fires when a
+# pre-generated .nono/profile.json or a --profile override skips that block —
+# the tailscale serve grant should follow the project, not the profile shape.
+hugo_enabled=0
+if [[ -f "$project_root/hugo.toml" || -f "$project_root/hugo.yaml" || -f "$project_root/hugo.json" ||
+    -d "$project_root/config/_default" ||
+    (-f "$project_root/config.toml" && -d "$project_root/themes") ]]; then
+    hugo_enabled=1
+fi
+
+# Hugo dev server over Tailscale. `hugo server` binds a single interface; to
+# preview a build from another tailnet device (phone, laptop) it must bind the
+# host's tailscale IPv4 rather than loopback. nono's network mediation is
+# port-based, so serving on that IP just needs the serve port opened for
+# listen; reaching it from *inside* the sandbox (curl, the Playwright MCP) also
+# needs the IP in NO_PROXY so the client connects directly instead of routing
+# through the credential proxy (which would block it). Prefer `tailscale ip -4`
+# (cross-platform, official); fall back to the Linux tailscale0 interface when
+# the CLI is unavailable or transiently empty. Gated on Hugo being detected so
+# non-Hugo sandboxes never probe for the IP. `|| true` keeps `set -e`/pipefail
+# from aborting when tailscale isn't installed or connected.
+tailscale_ip=""
+if ((hugo_enabled)); then
+    tailscale_ip=$(tailscale ip -4 2>/dev/null | head -1 || true)
+    if [[ -z $tailscale_ip ]]; then
+        tailscale_ip=$(ip -4 -o addr show tailscale0 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+    fi
+fi
+
 # --profile short-circuits discovery: resolve an existing file to an
 # absolute path (so it works regardless of cwd), otherwise pass the value
 # through as a profile name. With the override set, the walk-up below and
@@ -121,17 +155,10 @@ if [[ -z "$profile" ]]; then
     if [[ -f "$project_root/go.mod" ]]; then
         mixins+=("oalders-go")
     fi
-    # Hugo: modern config names (hugo.toml/yaml/json), the modular
-    # config/_default/ layout, OR legacy config.toml paired with themes/.
-    # The bare hugo.* names and config/_default/ are Hugo-specific, so they
-    # need no themes/ guard; only config.toml does (it guards against false
-    # positives on any other TOML-using project). Pulls in oalders-snap
-    # because Hugo on Linux is typically installed via snap, which needs
-    # /snap, /var/lib/snapd, and /etc/fstab readable to clear snapd's
-    # startup checks.
-    if [[ -f "$project_root/hugo.toml" || -f "$project_root/hugo.yaml" || -f "$project_root/hugo.json" ||
-        -d "$project_root/config/_default" ||
-        (-f "$project_root/config.toml" && -d "$project_root/themes") ]]; then
+    # Hugo (detected once above): pulls in oalders-snap because Hugo on Linux
+    # is typically installed via snap, which needs /snap, /var/lib/snapd, and
+    # /etc/fstab readable to clear snapd's startup checks.
+    if ((hugo_enabled)); then
         mixins+=("oalders-snap" "oalders-hugo")
     fi
     if (( ${#mixins[@]} > 0 )); then
@@ -280,6 +307,34 @@ if ((playwright_enabled)); then
     done
 fi
 
+# Hugo dev server ports. When Hugo is detected AND the host has a tailscale
+# IPv4 (see the detection near the top), open Hugo's default serve port and a
+# few above it so `hugo server --bind $TAILSCALE_IP` can bind+listen (the
+# default chain's open_port [80, 5000, 5001, 8080] doesn't cover 1313). The
+# small 1313-1316 block leaves room for a second instance or a custom --port
+# near the default. --open-port grants connect + listen, so an in-sandbox tool
+# (curl, the Playwright MCP) can also load the served site to inspect it.
+# $TAILSCALE_IP is exported below and the IP is appended to NO_PROXY so that
+# in-sandbox connection goes direct instead of through the credential proxy.
+# Gated on a tailscale IP existing so non-tailnet Hugo sandboxes keep the ports
+# closed.
+# NO_PROXY normally covers only loopback (see the exec below); the Hugo block
+# appends the tailscale IP so in-sandbox clients reach the served site directly
+# rather than via the proxy, which has no allow_domain entry for it.
+hugo_run_args=()
+hugo_env=()
+no_proxy_value="localhost,127.0.0.1"
+if ((hugo_enabled)) && [[ -n $tailscale_ip ]]; then
+    hugo_base_port=1313
+    for ((p = hugo_base_port; p <= hugo_base_port + 3; p++)); do
+        hugo_run_args+=(--open-port "$p")
+    done
+    hugo_env=("TAILSCALE_IP=$tailscale_ip")
+    no_proxy_value="$no_proxy_value,$tailscale_ip"
+    echo "🗯️nn: Hugo + tailscale $tailscale_ip — ports 1313-1316 open, \$TAILSCALE_IP set" >&2
+    echo "🗯️nn: serve with: hugo server --bind \$TAILSCALE_IP --baseURL http://\$TAILSCALE_IP:1313/" >&2
+fi
+
 # Opt-in clodhopper wiring. clodhopper init --local writes the hooks into
 # .claude/settings.local.json (gitignored). --settings adds a settings source;
 # it doesn't replace the project hierarchy, so claude still loads
@@ -367,8 +422,9 @@ set -x
 # of every override profile. Redundant grants are harmless.
 exec nono run --profile "$profile" --allow-cwd --workdir . \
     --read-file /usr/bin/env "${chrome_run_args[@]+"${chrome_run_args[@]}"}" \
-    "${playwright_run_args[@]+"${playwright_run_args[@]}"}" "${extra_allow[@]}" -- \
-    env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 TMPDIR="$PWD/.tmp" \
+    "${playwright_run_args[@]+"${playwright_run_args[@]}"}" \
+    "${hugo_run_args[@]+"${hugo_run_args[@]}"}" "${extra_allow[@]}" -- \
+    env NO_PROXY="$no_proxy_value" no_proxy="$no_proxy_value" TMPDIR="$PWD/.tmp" \
     XDG_CACHE_HOME="$PWD/.tmp/cache" \
     PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/ms-playwright" \
     NPM_CONFIG_CACHE="$PWD/.tmp/cache/npm" \
@@ -376,5 +432,6 @@ exec nono run --profile "$profile" --allow-cwd --workdir . \
     DISABLE_AUTOUPDATER=1 \
     COLORTERM=truecolor \
     "${chrome_env[@]+"${chrome_env[@]}"}" \
+    "${hugo_env[@]+"${hugo_env[@]}"}" \
     claude --settings "$session_settings" \
     --dangerously-skip-permissions "$@" "${auto_prompt[@]+"${auto_prompt[@]}"}"

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -53,7 +53,7 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 | `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), XS system C headers (`/usr/include`, `/usr/local/include`). Net-free; CPAN/MetaCPAN/MagPie network is in the paired `oalders-perl-net` (appended alongside it by `nn`). |
 | `oalders-node`  | `package.json`                        | `*.npmjs.org`, `registry.npmjs.org` (npm registry network access for installs)     |
 | `oalders-go`    | `go.mod`                              | Go toolchain (`go_runtime` group), build/module/lint caches (`~/.cache/go-build`, `~/.cache/golangci-lint`, `~/go/pkg/mod`), module proxy + checksum DB (`proxy.golang.org`, `sum.golang.org`), and cgo system headers (`/usr/include`, `/usr/local/include`, `/opt/homebrew/include`, pkg-config dirs, `/Library/Developer/CommandLineTools`) |
-| `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). When Hugo matches, `nn` also appends `oalders-snap` to the mixin list because Hugo on Linux is typically snap-installed. |
+| `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). When Hugo matches, `nn` also appends `oalders-snap` to the mixin list because Hugo on Linux is typically snap-installed, and — if the host is on a tailnet — opens Hugo's serve ports over the tailscale IP (see §2c). |
 | `oalders-snap`  | (no markers of its own — `nn` appends it alongside any snap-backed sibling like `oalders-hugo`) | Reads for snap-confined binaries: `/snap`, `/var/lib/snapd`, `/etc/fstab` (snapd's startup checks parse the mount table). |
 
 Example wrapper for a Node + Perl repo (`package.json` + `cpanfile` at top):
@@ -168,6 +168,18 @@ The MCP serves the Chrome DevTools endpoint over a localhost TCP port (its defau
 The Playwright MCP drives the browser over a pipe, so it needs no port — but running actual Playwright **tests** in the sandbox does. Two consumers bind localhost TCP the default chain doesn't cover, so `bind()` is Landlock-denied (`permission denied 127.0.0.1:<port>`): Playwright's HTML report / trace viewer (preferredPort `9323`, increments when busy) and any local preview / `config.webServer` that serves the build for the browser to load.
 
 `bin/nn` opens a 20-port block `9323–9342` with repeated `nono run --open-port` (same CLI-flag rationale as the DevTools port above). `9323` is Playwright's own default so the reporter works untouched; `9324–9342` are free for a preview/`webServer` — **serve within this range** (e.g. `python -m http.server 9324 --bind 127.0.0.1`), since a bind outside it is still denied. Scoped to `playwright_enabled` (e2e markers present, or `--playwright`) so idle/non-e2e sandboxes keep the ports closed.
+
+### 2c. Hugo serve ports over Tailscale (1313–1316)
+
+`hugo server` binds a single interface. To preview a build from another tailnet device (phone, laptop), it must bind the host's **tailscale IPv4** rather than loopback: `hugo server --bind $TAILSCALE_IP --baseURL http://$TAILSCALE_IP:1313/`. nono's network mediation is port-based, so serving on that IP just needs the serve port opened; the default chain's `open_port [80, 5000, 5001, 8080]` doesn't cover Hugo's default `1313`.
+
+When Hugo is detected (same markers as the `oalders-hugo` mixin: `hugo.toml`/`yaml`/`json`, `config/_default/`, or `config.toml` + `themes/`) **and** the host has a tailscale IPv4, `bin/nn`:
+
+- opens the `1313–1316` block with repeated `nono run --open-port` (same CLI-flag rationale as the ports above) — the small range leaves room for a second instance or a custom `--port` near the default;
+- exports `TAILSCALE_IP` so the `--bind`/`--baseURL` command above is copy-pasteable and scripts can reference it;
+- appends the tailscale IP to `NO_PROXY`, so an **in-sandbox** client (curl, the Playwright MCP) reaches the served site directly instead of routing through the credential proxy — which has no `allow_domain` entry for it and would block the connection.
+
+The IPv4 comes from `tailscale ip -4` (cross-platform), falling back to the Linux `tailscale0` interface via `ip addr`. Gated on a tailscale IP actually existing, so non-tailnet Hugo sandboxes keep the ports closed and `NO_PROXY` at loopback. Detection lives near the top of `bin/nn` (not only in the mixin auto-gen block) so the grant still fires when a pre-generated `.nono/profile.json` or a `--profile` override skips that block — the serve grant follows the project, not the profile shape.
 
 ## Kernel requirement
 

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -19,6 +19,11 @@ setup() {
     echo '{}' > "$HOME/.config/nono/serena_config.yml"
     # Stub nono to dump its argv to a file we can grep.
     stub_command nono 'printf "%s\n" "$@" > "$BATS_TEST_TMPDIR/nono-argv"'
+    # Default to "no tailscale IP" so Hugo detection doesn't probe the real
+    # host (which would leak the runner's tailscale IP into argv and make
+    # tests non-hermetic). The Hugo-over-tailscale test overrides tailscale.
+    stub_command tailscale 'exit 0'
+    stub_command ip 'exit 0'
     # Clean cwd outside any git work tree.
     mkdir -p "$BATS_TEST_TMPDIR/work"
     cd "$BATS_TEST_TMPDIR/work"
@@ -417,4 +422,50 @@ setup() {
     [ "$status" -eq 0 ]
     [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
     ! grep -Fxq -- "--playwright" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn opens Hugo serve ports and wires the tailscale IP when one exists" {
+    # A Hugo project on a tailnet host should be servable to other devices via
+    # `hugo server --bind $TAILSCALE_IP`. That needs three things, asserted
+    # together here: the serve ports opened for bind+listen, the IP exported as
+    # $TAILSCALE_IP, and the IP added to NO_PROXY so in-sandbox inspection
+    # (curl / the Playwright MCP) reaches the served site directly instead of
+    # through the credential proxy.
+    echo '{"baseURL": "https://example.com/"}' > hugo.json
+    stub_command tailscale 'if [ "$1" = "ip" ]; then echo "100.72.160.52"; fi'
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # Exactly the 1313-1316 block, no wider and no narrower.
+    [ "$(grep -Fxc -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv")" -eq 4 ]
+    grep -Fxq -- "1313" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "1316" "$BATS_TEST_TMPDIR/nono-argv"
+    ! grep -Fxq -- "1312" "$BATS_TEST_TMPDIR/nono-argv"
+    ! grep -Fxq -- "1317" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "TAILSCALE_IP=100.72.160.52" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "NO_PROXY=localhost,127.0.0.1,100.72.160.52" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "no_proxy=localhost,127.0.0.1,100.72.160.52" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn opens no Hugo ports when the host has no tailscale IP" {
+    # The serve grant is scoped to hosts that actually have a tailscale IPv4
+    # (the default setup() stubs make tailscale/ip return nothing). Without
+    # one there is nothing to serve to, so the ports stay closed, NO_PROXY
+    # keeps only loopback, and $TAILSCALE_IP is never set.
+    echo '{"baseURL": "https://example.com/"}' > hugo.json
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ "$(grep -Fxc -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv")" -eq 0 ]
+    ! grep -Fq -- "TAILSCALE_IP=" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "NO_PROXY=localhost,127.0.0.1" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn does not probe for a tailscale IP outside Hugo projects" {
+    # The tailscale grant is Hugo-scoped: a non-Hugo sandbox opens no serve
+    # ports and leaves NO_PROXY at loopback even if the host is on a tailnet.
+    stub_command tailscale 'if [ "$1" = "ip" ]; then echo "100.72.160.52"; fi'
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ "$(grep -Fxc -- "--open-port" "$BATS_TEST_TMPDIR/nono-argv")" -eq 0 ]
+    ! grep -Fq -- "TAILSCALE_IP=" "$BATS_TEST_TMPDIR/nono-argv"
+    grep -Fxq -- "NO_PROXY=localhost,127.0.0.1" "$BATS_TEST_TMPDIR/nono-argv"
 }


### PR DESCRIPTION
## What

When a Hugo project is detected **and** the host has a tailscale IPv4, `bin/nn` now sets up the sandbox to serve the site over tailscale and inspect it:

- Opens Hugo's serve ports (`1313–1316`) via `--open-port` so `hugo server --bind $TAILSCALE_IP` can bind+listen (the default chain's `open_port` doesn't cover 1313).
- Exports `$TAILSCALE_IP` and prints a copy-pasteable serve command.
- Appends the tailscale IP to `NO_PROXY` so an in-sandbox client (curl, the Playwright MCP) reaches the served site directly instead of through the credential proxy.

Hugo detection is factored to the top of `bin/nn` so the grant follows the project even when a pre-generated `.nono/profile.json` or a `--profile` override skips the mixin auto-gen block. Gated on a tailscale IP existing, so non-tailnet Hugo sandboxes keep the ports closed and `NO_PROXY` at loopback.

## Why

nono's network mediation is port-based, so serving on the tailscale IP just needs the serve port opened; the IP is what Hugo binds to. This lets the site be served to other tailnet devices and inspected from inside the sandbox.

## Tests

3 new `test/nn.bats` cases (39 pass total): ports + `TAILSCALE_IP` + `NO_PROXY` wired when a tailscale IP exists; nothing opened when it doesn't; no tailscale probing outside Hugo projects. `nono/CLAUDE.md` gains a §2c documenting the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)