### PR TITLE
cpan: retry the cpm download to survive transient 429s

### DIFF
--- a/installer/cpan.sh
+++ b/installer/cpan.sh
@@ -20,7 +20,7 @@ fi
 if ! is there cpm; then
     tmpscript=$(mktemp)
     trap 'rm -f "$tmpscript"' EXIT
-    curl -fsSL --compressed -o "$tmpscript" https://raw.githubusercontent.com/skaji/cpm/v0.999.0/cpm
+    curl -fsSL --compressed --retry 5 --retry-delay 2 --retry-all-errors -o "$tmpscript" https://raw.githubusercontent.com/skaji/cpm/v0.999.0/cpm
     perl "$tmpscript" install --global App::cpm
 fi
 


### PR DESCRIPTION
## Summary

The `Build` workflow intermittently fails during `./install.sh` when the `cpm` bootstrap in `installer/cpan.sh` fetches `raw.githubusercontent.com/skaji/cpm` and gets an HTTP `429` (rate limited). `curl` surfaces that as exit code 22, which fails the whole job — e.g. [run 28917227368](https://github.com/oalders/dot-files/actions/runs/28917227368) on `642946ab`. The very next commit passed with no code change, confirming it was transient.

This adds `--retry 5 --retry-delay 2 --retry-all-errors` to that one `curl` so a transient rate-limit is retried rather than failing the install. `--retry-all-errors` (curl ≥ 7.71) is needed because `--retry` alone does not retry HTTP 4xx like 429.

No behavior change on success; only adds resilience to the flaky download.

## Note

Other installers fetch scripts with plain `curl` too (`dev-vm-install.sh`, `installer/claude.sh`). I scoped this PR to the download that actually failed CI; happy to give the siblings the same treatment in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)