### PR TITLE
Enforce Claude Code context and subagent caps in settings.json

### DIFF
--- a/configure/claude-settings.sh
+++ b/configure/claude-settings.sh
@@ -30,9 +30,44 @@ set_env_key() {
     echo "set env.$key=$value in $SETTINGS"
 }
 
+# Like set_env_key, but for a top-level key whose value is raw JSON (bool,
+# number, string, object) rather than a string env var.
+set_key() {
+    local key=$1 value=$2
+
+    if jq -e --arg k "$key" --argjson v "$value" '.[$k] == $v' "$SETTINGS" >/dev/null; then
+        return
+    fi
+
+    jq --arg k "$key" --argjson v "$value" '.[$k] = $v' "$SETTINGS" >"$SETTINGS.tmp"
+    mv "$SETTINGS.tmp" "$SETTINGS"
+    echo "set $key=$value in $SETTINGS"
+}
+
 # Pin the claude binary; installer/claude.sh owns which version we land on.
 set_env_key DISABLE_AUTOUPDATER 1
 
 # ...but keep plugins updating, which DISABLE_AUTOUPDATER would otherwise
 # freeze alongside the CLI.
 set_env_key FORCE_AUTOUPDATE_PLUGINS 1
+
+# Compact automatically instead of needing a manual /compact. Compaction fires
+# at window-33k (20k reserved for output, 13k buffer), and the window itself is
+# clamped to the model max -- so on a 200k model anything above 200000 is a
+# no-op, and anything below just compacts sooner for no saving. 200000 is the
+# max useful value; it also keeps the clamp meaningful if 1M context is ever
+# re-enabled above.
+set_key autoCompactEnabled true
+set_key autoCompactWindow 200000
+
+# Stay on 200k-class context instead of the native 1M window some models (e.g.
+# Sonnet 5) offer. Long context is rarely worth the spend here, and a hard
+# ceiling keeps sessions focused. This is the setting that actually caps token
+# spend -- autoCompactWindow above only moves when compaction fires.
+set_env_key CLAUDE_CODE_DISABLE_1M_CONTEXT 1
+
+# Cap concurrently-running subagents so one message can't fan out unbounded
+# background agents. Added in claude 2.1.217, where it defaults to 20; inert on
+# older versions. DISABLE_AUTOUPDATER above means installer/claude.sh decides
+# when we actually land on a version that reads this.
+set_env_key CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS 5


### PR DESCRIPTION
`~/.claude/settings.json` is untracked, so `configure/claude-settings.sh` merges individual keys into whatever is already there. This adds a `set_key` helper alongside `set_env_key` for top-level keys whose values are raw JSON rather than string env vars, and uses it to pin auto-compact.

## Keys enforced

- `autoCompactEnabled: true` — compact automatically instead of needing a manual `/compact`.
- `autoCompactWindow: 200000` — only decides *when* compaction fires (at `window - 33k`) and is clamped to `min(modelMax, configured)`, so `200000` is the max useful value on a 200k model. Lower would just compact sooner and pay for an extra summarization call each time; higher is a no-op.
- `CLAUDE_CODE_DISABLE_1M_CONTEXT: 1` — the setting that actually caps token spend: stays on 200k-class context even on models with a native 1M window (e.g. Sonnet 5).
- `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS: 5` — lands in claude 2.1.217 (default 20); inert until `installer/claude.sh` takes us there.

`precious lint` passes; the script is idempotent (re-running is a clean no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)