### PR TITLE
Tear down worktree docker containers on merge/remove

### DIFF
--- a/bin/docker-teardown
+++ b/bin/docker-teardown
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# docker-teardown - remove docker containers a worktree session started.
+#
+# Given a worktree path (and optionally its branch), removes the docker
+# containers that provably belong to that worktree: the `bin/dev` container
+# for the worktree+branch, and any `docker compose` containers whose project
+# working directory is at or under the worktree. Session volumes are kept.
+#
+# Why this exists: containers are children of the docker daemon, not of the
+# tmux pane or the nono/claude/serena process tree. So neither
+# `kill-worktree-procs` (which walks /proc cwd + nono/claude ancestry) nor
+# `tmux kill-session` touches them. Left behind, they keep running with the
+# worktree deleted. The worktree-removal scripts (merge-pr, remove-worktree)
+# call this helper just before `kill-worktree-procs`.
+#
+# Safety — this NEVER does a bare `docker ps` sweep. A container is a target
+# only when its ownership of THIS worktree is provable:
+#   * compose: the `com.docker.compose.project.working_dir` label is $wt or
+#     a path under it;
+#   * bin/dev: the container name is exactly `<basename $wt>-<branch>`, which
+#     is how bin/dev derives it (repo basename + branch, '/' -> '-').
+# Ad-hoc `docker run` containers carry no such handle and are left alone
+# (with a note), matching the "minimize false positives" bias of the other
+# teardown helpers.
+
+set -u
+
+usage() {
+    cat <<'EOF'
+Usage: docker-teardown [-n|--dry-run] WORKTREE_PATH [BRANCH]
+
+Removes docker containers that belong to WORKTREE_PATH: the bin/dev
+container for WORKTREE_PATH+BRANCH and any docker-compose containers whose
+project working_dir is at or under WORKTREE_PATH. Session volumes are kept.
+
+  -n, --dry-run   Report what would be removed; remove nothing.
+  -h, --help      Show this help.
+
+A missing docker CLI or an unreachable daemon is not an error: the helper
+warns and exits 0 so worktree teardown is never blocked on docker.
+EOF
+}
+
+dry=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -n | --dry-run)
+        dry=1
+        shift
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    -*)
+        echo "docker-teardown: unknown option: $1" >&2
+        exit 2
+        ;;
+    *) break ;;
+    esac
+done
+
+wt="${1:-}"
+if [ -z "$wt" ]; then
+    usage >&2
+    exit 2
+fi
+branch="${2:-}"
+
+wt="${wt%/}"
+# Resolve symlinks so the label comparison matches what compose recorded.
+# Callers run us before `git worktree remove`, so the dir normally still
+# exists; if it doesn't, fall back to the path as given.
+if [ -d "$wt" ]; then
+    wt="$(cd "$wt" && pwd -P)"
+fi
+
+# No docker, or a daemon we can't reach: warn and succeed. Teardown of the
+# worktree itself must not hinge on docker being available.
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker-teardown: docker not found; skipping container cleanup" >&2
+    exit 0
+fi
+if ! docker ps -q >/dev/null 2>&1; then
+    echo "docker-teardown: docker daemon unreachable; skipping container cleanup" >&2
+    exit 0
+fi
+
+targets=""
+
+# Source 1 — compose containers owned by this worktree. Enumerate every
+# container carrying a project working_dir label, then keep only those whose
+# value is $wt or a path beneath it. `-a` so stopped-but-lingering containers
+# are caught too. The tab-delimited format keeps ID and label value paired.
+wd_label="com.docker.compose.project.working_dir"
+while IFS=$'\t' read -r id wd; do
+    [ -n "$id" ] || continue
+    case "$wd" in
+    "$wt" | "$wt"/*)
+        targets="$targets $id"
+        ;;
+    esac
+done < <(docker ps -a --filter "label=$wd_label" \
+    --format "{{.ID}}"$'\t'"{{.Label \"$wd_label\"}}" 2>/dev/null)
+
+# Source 2 — the bin/dev container for this worktree+branch. bin/dev names it
+# `<repo>-<branch>` where repo is the worktree dir basename and branch has
+# '/' rewritten to '-'. Only attempt this when a branch was supplied.
+if [ -n "$branch" ]; then
+    dev_name="$(basename "$wt")-$(printf '%s' "$branch" | tr '/' '-')"
+    # Anchor the name filter so `dot-files-feature` doesn't also match
+    # `dot-files-feature-2`.
+    dev_id="$(docker ps -aq --filter "name=^${dev_name}$" 2>/dev/null)"
+    [ -n "$dev_id" ] && targets="$targets $dev_id"
+fi
+
+# Dedup to one ID per line. A dev container has no compose label, so overlap
+# is unexpected, but guarding is cheap. The `^[0-9a-f]+$` filter keeps only
+# real container IDs (docker's are lowercase hex), so a stray token from a
+# mis-parsed row can never reach `docker rm -f`.
+targets="$(printf '%s' "$targets" | tr ' ' '\n' | grep -E '^[0-9a-f]+$' | sort -u)"
+
+if [ -z "$targets" ]; then
+    echo "docker-teardown: no worktree-owned containers under $wt"
+    exit 0
+fi
+
+count="$(printf '%s\n' "$targets" | wc -l | tr -d ' ')"
+
+if [ "$dry" = 1 ]; then
+    echo "docker-teardown: DRY RUN - would remove $count container(s) owned by $wt:"
+    while IFS= read -r id; do
+        docker ps -a --filter "id=$id" \
+            --format '  {{.ID}}  {{.Names}}  {{.Status}}' 2>/dev/null
+    done <<<"$targets"
+    exit 0
+fi
+
+echo "docker-teardown: removing $count container(s) owned by $wt"
+# `rm -f` stops (SIGKILL) then removes; volumes are intentionally left in
+# place (bin/dev's session volume persists Claude history across runs).
+# $targets is one non-empty ID per line here, so xargs always runs once.
+if ! printf '%s\n' "$targets" | xargs docker rm -f >/dev/null 2>&1; then
+    echo "docker-teardown: warning: one or more containers could not be removed" >&2
+fi
+echo "docker-teardown: done"

--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -349,6 +349,14 @@ fi
 #      session, this terminates the script. Nothing may follow.
 cd "$main_repo"
 
+# Remove docker containers this worktree's session started (bin/dev and
+# docker-compose). They're children of the docker daemon, not the process
+# tree kill-worktree-procs walks, so they'd otherwise survive teardown.
+teardown_docker="$(dirname "${BASH_SOURCE[0]}")/docker-teardown"
+if [ -x "$teardown_docker" ]; then
+    "$teardown_docker" "$worktree_path" "$branch" || true
+fi
+
 # Kill any agent process trees (nono/claude/serena) still running inside
 # the worktree before we remove it. Otherwise they live on with cwd
 # "(deleted)", accumulate over days, exhaust RAM and spike load average.

--- a/bin/remove-worktree
+++ b/bin/remove-worktree
@@ -40,6 +40,14 @@ if [[ -z $worktree_path ]]; then
     worktree_path="$branch_name"
 fi
 
+# Remove docker containers this worktree's session started (bin/dev and
+# docker-compose). They're children of the docker daemon, not the process
+# tree kill-worktree-procs walks, so they'd otherwise survive teardown.
+teardown_docker="$(dirname "${BASH_SOURCE[0]}")/docker-teardown"
+if [ -x "$teardown_docker" ]; then
+    "$teardown_docker" "$worktree_path" "$branch_name" || true
+fi
+
 # Kill any agent process trees (nono/claude/serena) still running inside
 # the worktree before we remove it. tmux kill-session above only SIGHUPs
 # the pane shell; sandboxed claude trees often survive that.

--- a/test/docker-teardown.bats
+++ b/test/docker-teardown.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+load 'helpers.bash'
+
+# A `docker` stub that emulates just the queries docker-teardown makes, driven
+# by env vars the tests set:
+#   DOCKER_DAEMON_OK      "1" (default) => `docker ps -q` succeeds; else fails.
+#   DOCKER_COMPOSE_ROWS   file of "<id><TAB><working_dir>" lines returned for
+#                         the compose label query.
+#   DOCKER_DEV_ID         id returned for the `--filter name=...` (bin/dev)
+#                         query; empty => no dev container.
+#   DOCKER_RM_LOG         file the stub appends `rm` arguments to, so a test
+#                         can assert exactly which ids were removed.
+docker_stub_body='
+case "${1:-}" in
+ps)
+    shift
+    if [ "${1:-}" = "-q" ] && [ "$#" -eq 1 ]; then
+        [ "${DOCKER_DAEMON_OK:-1}" = "1" ] && exit 0 || exit 1
+    fi
+    label_filter=""; name_filter=""; id_filter=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --filter)
+            shift
+            case "$1" in
+            label=*) label_filter="${1#label=}" ;;
+            name=*) name_filter="${1#name=}" ;;
+            id=*) id_filter="${1#id=}" ;;
+            esac
+            ;;
+        --format) shift ;;
+        esac
+        shift
+    done
+    if [ -n "$name_filter" ]; then
+        [ -n "${DOCKER_DEV_ID:-}" ] && echo "$DOCKER_DEV_ID"
+        exit 0
+    fi
+    if [ -n "$id_filter" ]; then
+        echo "  $id_filter  name-$id_filter  Up"
+        exit 0
+    fi
+    if [ -n "$label_filter" ]; then
+        [ -f "${DOCKER_COMPOSE_ROWS:-/nonexistent}" ] && cat "$DOCKER_COMPOSE_ROWS"
+        exit 0
+    fi
+    exit 0
+    ;;
+rm)
+    shift
+    printf "%s\n" "$*" >>"${DOCKER_RM_LOG:?}"
+    exit 0
+    ;;
+esac
+exit 0
+'
+
+setup() {
+    setup_sandbox
+    DT="$BIN_DIR/docker-teardown"
+    # A path we never create, so docker-teardown skips symlink resolution and
+    # uses it verbatim — keeps label fixtures deterministic.
+    WT="$BATS_TEST_TMPDIR/wt"
+    RM_LOG="$BATS_TEST_TMPDIR/rm.log"
+    : >"$RM_LOG"
+    export DOCKER_RM_LOG="$RM_LOG"
+    stub_command docker "$docker_stub_body"
+}
+
+@test "docker-teardown prints usage and exits 2 with no args" {
+    run "$DT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage: docker-teardown"* ]]
+}
+
+@test "docker-teardown -h exits 0" {
+    run "$DT" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: docker-teardown"* ]]
+}
+
+@test "docker-teardown rejects unknown option with exit 2" {
+    run "$DT" --bogus "$WT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown option"* ]]
+}
+
+@test "docker-teardown exits 0 and removes nothing when the daemon is unreachable" {
+    DOCKER_DAEMON_OK=0 run "$DT" "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"daemon unreachable"* ]]
+    [ ! -s "$RM_LOG" ]
+}
+
+@test "docker-teardown reports no owned containers when nothing matches" {
+    run "$DT" "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no worktree-owned containers"* ]]
+    [ ! -s "$RM_LOG" ]
+}
+
+@test "docker-teardown removes only compose containers under the worktree" {
+    rows="$BATS_TEST_TMPDIR/rows"
+    # One container at the worktree, one under a subdir (both owned), and one
+    # at an unrelated path (must be left alone).
+    printf 'aaa111\t%s\n' "$WT" >"$rows"
+    printf 'bbb222\t%s/subdir\n' "$WT" >>"$rows"
+    printf 'ccc333\t%s\n' "$BATS_TEST_TMPDIR/other" >>"$rows"
+    export DOCKER_COMPOSE_ROWS="$rows"
+
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+
+    removed="$(cat "$RM_LOG")"
+    [[ "$removed" == *aaa111* ]]
+    [[ "$removed" == *bbb222* ]]
+    [[ "$removed" != *ccc333* ]]
+}
+
+@test "docker-teardown removes the bin/dev container for the worktree+branch" {
+    export DOCKER_DEV_ID=abc123
+    run "$DT" "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$RM_LOG")" == *abc123* ]]
+}
+
+@test "docker-teardown dry-run lists targets but removes nothing" {
+    export DOCKER_DEV_ID=abc123
+    run "$DT" --dry-run "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY RUN"* ]]
+    [[ "$output" == *abc123* ]]
+    [ ! -s "$RM_LOG" ]
+}

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -11,6 +11,9 @@ setup() {
     # one. See test "pre-flight: refuses when not in a git work tree".
     export GIT_CEILING_DIRECTORIES
     GIT_CEILING_DIRECTORIES="$(dirname "$BATS_TEST_TMPDIR")"
+    # Stub docker so the docker-teardown step is hermetic: every query returns
+    # empty, so it finds no worktree-owned containers regardless of host state.
+    stub_command docker 'exit 0'
 }
 
 @test "merge-pr -h prints usage and exits 0" {

--- a/test/remove-worktree.bats
+++ b/test/remove-worktree.bats
@@ -8,6 +8,9 @@ setup() {
     # No tmux: stub pgrep so the tmux-session-kill block is skipped (an empty
     # `$(pgrep tmux)` short-circuits it). Mirrors add-worktree.bats.
     stub_command pgrep 'exit 1'
+    # Stub docker so the docker-teardown step is hermetic: every query returns
+    # empty, so it finds no worktree-owned containers regardless of host state.
+    stub_command docker 'exit 0'
     export GIT_CEILING_DIRECTORIES
     GIT_CEILING_DIRECTORIES="$(dirname "$BATS_TEST_TMPDIR")"
 }


### PR DESCRIPTION
## Problem

`merge-pr` and `remove-worktree` left docker containers running after deleting the worktree. Containers are children of the docker daemon (via containerd-shim), not of the tmux pane or the nono/claude/serena process tree — so neither `tmux kill-session` (only SIGHUPs the pane shell) nor `kill-worktree-procs` (walks /proc cwd + agent ancestry) ever touched them. They kept running with the worktree gone.

## Change

New `bin/docker-teardown [-n|--dry-run] WORKTREE_PATH [BRANCH]` removes only containers whose ownership of *this* worktree is **provable**:

- **compose** — `com.docker.compose.project.working_dir` label equals the worktree or a path under it;
- **bin/dev** — container name exactly `<basename wt>-<branch>` (anchored, so `dot-files-feature` won't match `dot-files-feature-2`).

Ad-hoc `docker run` containers carry no such handle and are left alone — there is never a bare `docker ps` sweep, matching the "minimize false positives" bias of the other teardown helpers. Session **volumes are kept** so bin/dev history survives. A missing docker CLI or unreachable daemon warns and exits 0, so worktree teardown never blocks on docker.

`merge-pr` and `remove-worktree` call the helper just before `kill-worktree-procs`.

## Tests

- New `test/docker-teardown.bats` — 8 hermetic tests (usage/exit codes, unreachable daemon, subdir compose ownership, unrelated-path exclusion, bin/dev match, dry-run).
- Stubbed `docker` in `merge-pr.bats`/`remove-worktree.bats` so their cleanup-path tests no longer touch the host daemon.

All 59 tests pass; `precious lint` and `shellcheck` clean. Also verified end-to-end against a real daemon: dry-run listed 3 owned containers (incl. a subdir one), real run removed all 3, an unrelated container survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)