### PR TITLE
Fix unbound variable in nn when launched outside a git repo

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -452,7 +452,7 @@ set -x
 exec nono run --profile "$profile" --allow-cwd --workdir . \
     --read-file /usr/bin/env "${chrome_run_args[@]+"${chrome_run_args[@]}"}" \
     "${playwright_run_args[@]+"${playwright_run_args[@]}"}" \
-    "${hugo_run_args[@]+"${hugo_run_args[@]}"}" "${extra_allow[@]}" -- \
+    "${hugo_run_args[@]+"${hugo_run_args[@]}"}" "${extra_allow[@]+"${extra_allow[@]}"}" -- \
     env NO_PROXY="$no_proxy_value" no_proxy="$no_proxy_value" TMPDIR="$PWD/.tmp" \
     XDG_CACHE_HOME="$PWD/.tmp/cache" \
     PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/ms-playwright" \


### PR DESCRIPTION
## Problem

Running `nn` outside a git repo aborted before launch:

```
bin/nn: line 427: extra_allow[@]: unbound variable
```

## Cause

The `exec nono run` line expanded `"${extra_allow[@]}"` without the
empty-array guard that the four sibling arrays on the same lines
(`chrome_run_args`, `playwright_run_args`, `hugo_run_args`, `chrome_env`) all
use.

`extra_allow` is only populated when `git rev-parse --git-common-dir`
succeeds, so outside a git repo it stays `()`.

`nn`'s shebang is `#!/bin/bash`, which on macOS is bash **3.2.57** — not a
5.x from `$PATH`. Under `set -u`, bash 3.2 treats expansion of an *empty*
array as an unbound variable; this was fixed in bash 4.4+. Reproduced:

| expansion (`a=()`, `set -u`) | bash 3.2 | bash 5.3 |
| --- | --- | --- |
| `"${a[@]}"` | `a[@]: unbound variable` | fine |
| `"${a[@]+"${a[@]}"}"` | fine | fine |

Inside a git repo the array is non-empty, so the unguarded form happened to
work — which is why this only surfaced on a non-repo launch.

## Fix

Apply the same `"${a[@]+"${a[@]}"}"` guard the neighbouring arrays use. One
line.

## Testing

- `/bin/bash -n bin/nn` passes
- `precious lint bin/nn` clean
- Guarded expansion verified against both bash 3.2 and 5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
