### PR TITLE
Support installing rbenv on Linux

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -21,11 +21,11 @@ if is there plenv; then
     eval "$(plenv init -)"
 fi
 
+if [[ -d ~/.rbenv ]]; then
+    add_path "$HOME/.rbenv/bin"
+fi
 if is there rbenv; then
-    if [[ -d ~/.rbenv ]]; then
-        add_path "$HOME/.rbenv/bin"
-        eval "$(rbenv init -)"
-    fi
+    eval "$(rbenv init -)"
 fi
 
 gcloud_completion="/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.bash.inc"

--- a/installer/rbenv.sh
+++ b/installer/rbenv.sh
@@ -3,12 +3,45 @@
 set -eu -o pipefail
 version=3.3.5
 
-if is os name ne 'darwin'; then
-    exit
-fi
+# shellcheck source=bash_functions.sh
+source ~/dot-files/bash_functions.sh
 
-if ! is there rbenv; then
-    brew install rbenv
+if is os name eq darwin; then
+    if ! is there rbenv; then
+        brew install rbenv
+    fi
+elif is os name eq linux; then
+    if [[ -d "$HOME/.rbenv/.git" ]]; then
+        cd "$HOME/.rbenv" || exit 1
+        git from
+        cd - || exit 1
+    else
+        rm -rf "$HOME/.rbenv"
+        git clone --depth 1 https://github.com/rbenv/rbenv.git "$HOME/.rbenv"
+    fi
+
+    ruby_build_dir="$HOME/.rbenv/plugins/ruby-build"
+    if [[ -d $ruby_build_dir/.git ]]; then
+        cd "$ruby_build_dir" || exit 1
+        git from
+        cd - || exit 1
+    else
+        git clone --depth 1 https://github.com/rbenv/ruby-build.git "$ruby_build_dir"
+    fi
+
+    add_path "$HOME/.rbenv/bin"
+
+    if [[ $IS_SUDOER == true ]] && is there apt; then
+        # Build deps ruby-build needs to compile Ruby from source.
+        sudo apt-get install -y -q --no-install-recommends \
+            libffi-dev \
+            libreadline-dev \
+            libssl-dev \
+            libyaml-dev \
+            zlib1g-dev
+    fi
+else
+    exit 0
 fi
 
 # Might need to initialize rbenv in the shell


### PR DESCRIPTION
## Summary
- `installer/rbenv.sh` previously exited immediately on non-macOS. Add a Linux branch that clones `rbenv` + the `ruby-build` plugin into `~/.rbenv` and installs the apt build deps ruby-build needs.
- Fix `bash_profile`: the `add_path "$HOME/.rbenv/bin"` call was nested inside `if is there rbenv`, but `rbenv` can only be found once its bin dir is already on `PATH` — a chicken-and-egg bug that's harmless on macOS (Homebrew already puts `rbenv` on `PATH`) but left Linux installs unreachable in a fresh shell.

## Test plan
- [x] `shfmt`/`shellcheck` clean on both changed files
- [x] Ran `installer/rbenv.sh` on this Ubuntu machine; confirmed `~/.rbenv` + `ruby-build` plugin installed
- [x] Opened a fresh shell after the `bash_profile` fix and confirmed `rbenv` resolves on `PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)