### PR TITLE
Fix CI: use source-file -q instead of if-shell guard in tmux.conf

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -39,7 +39,10 @@ set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
 # Underscore colours support (requires tmux 3.0+)
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
 
-if-shell "[ -f ~/.local/share/nvim/lazy/tokyonight.nvim/extras/tmux/tokyonight_moon.tmux ]" "source-file ~/.local/share/nvim/lazy/tokyonight.nvim/extras/tmux/tokyonight_moon.tmux"
+# `-q` sources the file only if it exists (no error otherwise), the tmux-native
+# equivalent of an `if-shell [ -f ... ]` guard. tpack's config parser rejects a
+# source-file nested in an if-shell quoted command list, so keep this top-level.
+source-file -q ~/.local/share/nvim/lazy/tokyonight.nvim/extras/tmux/tokyonight_moon.tmux
 
 # Override the "bold" in tokyonight_moon status-left
 set -g status-left "#[fg=#1b1d2b,bg=#82aaff] #S #[fg=#82aaff,bg=#1e2030,nobold,nounderscore,noitalics]"


### PR DESCRIPTION
## Problem

CI was failing at `configure/tmux.sh` (`tmux source ~/.tmux.conf`), which reported `'~/.tmux/plugins/tpm/tpm' returned 1` and exited the `set -e` script.

## Root cause

tpack's auto-downloaded binary now tracks **v2.0.0**, which statically follows `source`/`source-file` directives to scan them for `@plugin` lines. It **refuses** a `source-file` nested inside an `if-shell` quoted command list (it can't tell statically whether the source executes), aborting with:

```
executable quoted command list may contain source/source-file
```

`tmux.conf:42` was exactly that shape — an `if-shell "[ -f … ]" "source-file …"` guard for the tokyonight theme.

## Fix

Replace the `if-shell` guard with the tmux-native `source-file -q`: `-q` sources the file only if it exists and stays silent otherwise (matching the old `[ -f ]` behavior). It sits at top level, which tpack parses cleanly (`-q` → `Optional`, so a missing theme file is fine in CI).

## Verification

- Ran tpack v2.0.0 against the config before/after: the `tmux.conf:42` parse error disappears and execution advances past config parsing.
- Confirmed against tpack's source/tests that top-level `source-file -q` is the accepted form.
- Grepped `tmux.conf` — no other `if`/`if-shell` + source combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)