### PR TITLE
Fix worktree teardown: upstream repair and root-owned docker paths

### DIFF
--- a/bin/docker-teardown
+++ b/bin/docker-teardown
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 #
-# docker-teardown - remove docker containers a worktree session started.
+# docker-teardown - remove docker artifacts a worktree session left behind.
 #
 # Given a worktree path (and optionally its branch), removes the docker
 # containers that provably belong to that worktree: the `bin/dev` container
 # for the worktree+branch, and any `docker compose` containers whose project
 # working directory is at or under the worktree. Session volumes are kept.
+#
+# It then reclaims ownership of files those containers wrote into the worktree
+# as root (bind-mounted data dirs — see "ownership reclaim" below).
 #
 # Why this exists: containers are children of the docker daemon, not of the
 # tmux pane or the nono/claude/serena process tree. So neither
@@ -33,6 +36,9 @@ Usage: docker-teardown [-n|--dry-run] WORKTREE_PATH [BRANCH]
 Removes docker containers that belong to WORKTREE_PATH: the bin/dev
 container for WORKTREE_PATH+BRANCH and any docker-compose containers whose
 project working_dir is at or under WORKTREE_PATH. Session volumes are kept.
+
+Then chowns back any path under WORKTREE_PATH that a container wrote as
+root, so `git worktree remove` can delete the tree.
 
   -n, --dry-run   Report what would be removed; remove nothing.
   -h, --help      Show this help.
@@ -123,25 +129,90 @@ targets="$(printf '%s' "$targets" | tr ' ' '\n' | grep -E '^[0-9a-f]+$' | sort -
 
 if [ -z "$targets" ]; then
     echo "docker-teardown: no worktree-owned containers under $wt"
+else
+    count="$(printf '%s\n' "$targets" | wc -l | tr -d ' ')"
+
+    if [ "$dry" = 1 ]; then
+        echo "docker-teardown: DRY RUN - would remove $count container(s) owned by $wt:"
+        while IFS= read -r id; do
+            docker ps -a --filter "id=$id" \
+                --format '  {{.ID}}  {{.Names}}  {{.Status}}' 2>/dev/null
+        done <<<"$targets"
+    else
+        echo "docker-teardown: removing $count container(s) owned by $wt"
+        # `rm -f` stops (SIGKILL) then removes; volumes are intentionally left
+        # in place (bin/dev's session volume persists Claude history across
+        # runs). $targets is one non-empty ID per line here, so xargs always
+        # runs once.
+        if ! printf '%s\n' "$targets" | xargs docker rm -f >/dev/null 2>&1; then
+            echo "docker-teardown: warning: one or more containers could not be removed" >&2
+        fi
+    fi
+fi
+
+# --- ownership reclaim ---------------------------------------------------
+#
+# A compose service that bind-mounts a directory from the worktree (a database
+# data dir, a certbot state dir) runs as root inside the container and creates
+# those files as root on the host. `git worktree remove --force` then dies with
+# "Permission denied" partway through the delete — and by then it has already
+# removed .git and unregistered the worktree, so what's left is an orphaned
+# directory tree that `git worktree list` no longer knows about. That is the
+# only thing standing between a clean teardown and a manual `sudo rm -rf`.
+#
+# Fix it the same way it was caused: a throwaway container running as root,
+# with the worktree bind-mounted, chowning the offending paths back to us. No
+# sudo, no password prompt.
+#
+# Runs even when no containers were found: the container that wrote the files
+# may have been removed days ago, or by a previous run of this script.
+
+if [ ! -d "$wt" ]; then
+    echo "docker-teardown: done"
     exit 0
 fi
 
-count="$(printf '%s\n' "$targets" | wc -l | tr -d ' ')"
+uid="$(id -u)"
+gid="$(id -g)"
+
+# Cheap detection first, so the common case never starts a container. A
+# root-owned directory we cannot descend into is itself reported by this find,
+# so being unable to read its contents costs us nothing. .git is skipped: it is
+# ours by construction and never bind-mounted.
+if ! find "$wt" -name .git -prune -o ! -user "$uid" -print 2>/dev/null | grep -q .; then
+    echo "docker-teardown: done"
+    exit 0
+fi
+
+# Pick an image that is already local before falling back to pulling one — a
+# teardown should not stall on a registry round trip if anything tiny is at
+# hand.
+reclaim_image=""
+for img in alpine:latest busybox:latest alpine busybox; do
+    if docker image inspect "$img" >/dev/null 2>&1; then
+        reclaim_image="$img"
+        break
+    fi
+done
+[ -n "$reclaim_image" ] || reclaim_image="alpine:latest"
 
 if [ "$dry" = 1 ]; then
-    echo "docker-teardown: DRY RUN - would remove $count container(s) owned by $wt:"
-    while IFS= read -r id; do
-        docker ps -a --filter "id=$id" \
-            --format '  {{.ID}}  {{.Names}}  {{.Status}}' 2>/dev/null
-    done <<<"$targets"
+    echo "docker-teardown: DRY RUN - would chown root-owned paths under $wt to $uid:$gid:"
+    find "$wt" -name .git -prune -o ! -user "$uid" -print 2>/dev/null | head -20
+    echo "docker-teardown: done"
     exit 0
 fi
 
-echo "docker-teardown: removing $count container(s) owned by $wt"
-# `rm -f` stops (SIGKILL) then removes; volumes are intentionally left in
-# place (bin/dev's session volume persists Claude history across runs).
-# $targets is one non-empty ID per line here, so xargs always runs once.
-if ! printf '%s\n' "$targets" | xargs docker rm -f >/dev/null 2>&1; then
-    echo "docker-teardown: warning: one or more containers could not be removed" >&2
+echo "docker-teardown: reclaiming root-owned paths under $wt"
+# The find runs *inside* the container, as root, so it reaches paths the host
+# find cannot descend into. -h chowns symlinks themselves rather than their
+# targets, which keeps a link pointing outside the worktree from redirecting
+# the chown there. The mount is the worktree and nothing else, so the blast
+# radius is exactly the tree we are about to delete.
+if ! docker run --rm --network none -v "$wt:/wt" "$reclaim_image" \
+    sh -c "find /wt -name .git -prune -o ! -user $uid -print0 | xargs -0 -r chown -h $uid:$gid" \
+    >/dev/null 2>&1; then
+    echo "docker-teardown: warning: could not reclaim root-owned paths under $wt;" >&2
+    echo "                 'git worktree remove' may fail with Permission denied." >&2
 fi
 echo "docker-teardown: done"

--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -122,6 +122,23 @@ if [[ -z "$close_mode" ]]; then
             read -r reply || reply=""
             case "$reply" in
                 [Yy]*)
+                    # --set-upstream-to needs refs/remotes/origin/<branch> to
+                    # exist locally, and it may not: origin has the branch (we
+                    # just asked it), but this clone may never have fetched it,
+                    # or the ref may be stale relative to what origin holds.
+                    # Both make the repair fail ("the requested upstream branch
+                    # does not exist") or leave the unpushed-commit check below
+                    # comparing against an out-of-date ref. Fetch the one ref
+                    # explicitly first — a full `git fetch` is unnecessary and
+                    # slow, and the explicit refspec avoids depending on the
+                    # remote's configured fetch refspec.
+                    # The leading "+" matches the standard remote-tracking
+                    # refspec: a stale local ref that isn't a fast-forward of
+                    # origin's still gets updated rather than failing.
+                    if ! git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" >&2; then
+                        echo "merge-pr: could not fetch 'refs/heads/$branch' from origin — cannot repair tracking." >&2
+                        exit 1
+                    fi
                     git branch --set-upstream-to="origin/$branch" >&2
                     ;;
                 *)

--- a/test/docker-teardown.bats
+++ b/test/docker-teardown.bats
@@ -11,6 +11,10 @@ load 'helpers.bash'
 #                         query; empty => no dev container.
 #   DOCKER_RM_LOG         file the stub appends `rm` arguments to, so a test
 #                         can assert exactly which ids were removed.
+#   DOCKER_IMAGE_LOCAL    "1" (default) => `docker image inspect` succeeds, so
+#                         the reclaim step finds a local image.
+#   DOCKER_RUN_LOG        file the stub appends `run` arguments to, so a test
+#                         can assert how the ownership-reclaim container ran.
 docker_stub_body='
 case "${1:-}" in
 ps)
@@ -52,6 +56,14 @@ rm)
     printf "%s\n" "$*" >>"${DOCKER_RM_LOG:?}"
     exit 0
     ;;
+image)
+    [ "${DOCKER_IMAGE_LOCAL:-1}" = "1" ] && exit 0 || exit 1
+    ;;
+run)
+    shift
+    printf "%s\n" "$*" >>"${DOCKER_RUN_LOG:?}"
+    exit 0
+    ;;
 esac
 exit 0
 '
@@ -65,7 +77,18 @@ setup() {
     RM_LOG="$BATS_TEST_TMPDIR/rm.log"
     : >"$RM_LOG"
     export DOCKER_RM_LOG="$RM_LOG"
+    RUN_LOG="$BATS_TEST_TMPDIR/run.log"
+    : >"$RUN_LOG"
+    export DOCKER_RUN_LOG="$RUN_LOG"
     stub_command docker "$docker_stub_body"
+}
+
+# A worktree-shaped directory whose contents are all ours. Sets WT to it,
+# replacing the never-created default so the ownership-reclaim step runs.
+make_real_worktree() {
+    WT="$BATS_TEST_TMPDIR/real-wt"
+    mkdir -p "$WT/live-mysql-data"
+    echo x >"$WT/live-mysql-data/ibdata"
 }
 
 @test "docker-teardown prints usage and exits 2 with no args" {
@@ -132,4 +155,63 @@ setup() {
     [[ "$output" == *"DRY RUN"* ]]
     [[ "$output" == *abc123* ]]
     [ ! -s "$RM_LOG" ]
+}
+
+# --- ownership reclaim ---------------------------------------------------
+#
+# The reclaim step exists because a compose service that bind-mounts a
+# worktree directory writes it as root, and `git worktree remove --force`
+# then dies with "Permission denied" *after* unregistering the worktree.
+# Creating a genuinely root-owned file in a test would need sudo, so these
+# tests stub `find` to report one instead — the stub PATH shadows it for
+# docker-teardown just as it does `docker`.
+
+@test "reclaim: no container is started when every path is already ours" {
+    make_real_worktree
+    run "$DT" "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"reclaiming"* ]]
+    [ ! -s "$RUN_LOG" ]
+}
+
+@test "reclaim: a root-owned path triggers a chown container over the worktree" {
+    make_real_worktree
+    stub_command find "printf '%s\n' \"\$2/live-mysql-data\""
+    run "$DT" "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaiming"* ]]
+    started="$(cat "$RUN_LOG")"
+    # Mounts exactly the worktree, and chowns to the invoking user.
+    [[ "$started" == *"-v $WT:/wt"* ]]
+    [[ "$started" == *"chown -h $(id -u):$(id -g)"* ]]
+    # Never reaches the network, and never touches .git.
+    [[ "$started" == *"--network none"* ]]
+    [[ "$started" == *"-name .git -prune"* ]]
+}
+
+@test "reclaim: dry-run reports the root-owned paths but starts no container" {
+    make_real_worktree
+    stub_command find "printf '%s\n' \"\$2/live-mysql-data\""
+    run "$DT" --dry-run "$WT" feature
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would chown"* ]]
+    [[ "$output" == *"live-mysql-data"* ]]
+    [ ! -s "$RUN_LOG" ]
+}
+
+@test "reclaim: a failed chown container warns but still exits 0" {
+    make_real_worktree
+    stub_command find "printf '%s\n' \"\$2/live-mysql-data\""
+    # Re-stub docker so only `run` fails. No containers match in this test, so
+    # the trimmed `ps` handling is enough.
+    stub_command docker "case \"\${1:-}\" in
+ps) exit 0 ;;
+image) exit 0 ;;
+run) exit 1 ;;
+esac
+exit 0"
+    run "$DT" "$WT" feature
+    # Teardown must never block worktree removal on docker.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"could not reclaim"* ]]
 }

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -102,6 +102,28 @@ setup() {
     [[ "$output" == "origin" ]]
 }
 
+# The branch is on origin but this clone has no refs/remotes/origin/<branch>
+# (pushed from elsewhere, or the tracking ref was pruned). --set-upstream-to
+# alone fails there with "the requested upstream branch does not exist", so
+# the repair has to fetch the ref first.
+@test "pre-flight: tracking repair works with no local remote-tracking ref" {
+    setup_git_repo
+    setup_upstream
+    git checkout -q -b feature
+    git push -q origin feature
+    git branch -q -D -r origin/feature
+    git config --unset branch.feature.remote || true
+    git config --unset branch.feature.merge || true
+    stub_command gh 'exit 1'
+    run "$MERGE_PR" <<<"y"
+    # Reaching PR lookup (which the gh stub fails) proves the repair worked.
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no PR found"* ]]
+    run git rev-parse --abbrev-ref --symbolic-full-name '@{u}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "origin/feature" ]]
+}
+
 # A genuinely unpushed branch whose name is a path suffix of an existing
 # remote branch (e.g. local "foo" vs remote "feature/foo") must still get
 # "push first", not the repair prompt. Guards against ls-remote tail-match.


### PR DESCRIPTION
Two independent bugs that together made `merge-pr` unusable in a repo whose
docker-compose stack bind-mounts data directories out of the worktree
(`www-wunderbill-com`).

## 1. `merge-pr`: repair the upstream, don't just try to

When `@{u}` doesn't resolve but the branch *is* on origin, merge-pr offers to
repair the tracking config. That repair ran `git branch
--set-upstream-to=origin/<branch>`, which needs `refs/remotes/origin/<branch>`
to exist locally — and it may not, if this clone never fetched it. The repair
then dies:

```
fatal: the requested upstream branch 'origin/fix-15' does not exist
```

Now it fetches that single ref first. The `+` matches the standard
remote-tracking refspec, so a stale local ref is updated rather than rejected
as a non-fast-forward — which also stops the unpushed-commit check that follows
from comparing against out-of-date data.

## 2. `docker-teardown`: reclaim root-owned paths

A compose service that bind-mounts a directory out of the worktree (a database
data dir, a certbot state dir) runs as root in the container and creates those
files as root on the host. `git worktree remove --force` then dies with
`Permission denied` partway through the delete — and by then it has already
removed `.git` and unregistered the worktree. What's left is an orphaned tree
that `git worktree list` no longer knows about and only `sudo rm -rf` can
clear. Three of them had accumulated in `~/.worktree/www-wunderbill-com/`.

Fixed the way it was caused: a throwaway `--network none` container, running as
root with the worktree bind-mounted, chowning the offending paths back. No
sudo, no password prompt. Detection is a host-side `find` that short-circuits
before starting any container, so the common case is unchanged. A failure warns
and still exits 0 — teardown must never block on docker.

Reproduction, before and after the fix:

```
--- remove WITH force ---
error: failed to delete '.../wt': Permission denied
--- leftovers ---
.../wt/live-mysql-data
```

### Not the submodule case

Worth recording, since it looks like one: `git worktree remove --force` deletes
a worktree's submodules fine. In the reproduction above the submodule tree was
gone and only the root-owned dirs survived. (Without `--force` git does refuse
— `working trees containing submodules cannot be moved or removed` — but
merge-pr already forces whenever `.gitmodules` exists.) Ownership was the only
thing blocking teardown.

## Testing

Full bats suite passes (138 tests), shellcheck clean. Adds 4 tests for the
reclaim step (no-op when everything is ours, the chown container's mount /
user / `--network none` / `.git` prune, dry-run, and failure-warns-but-exits-0)
and 1 regression test for the tracking fetch with no local remote-tracking ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)