### PR TITLE
nono: redirect buildx state to the worktree instead of granting ~/.docker/buildx

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -373,6 +373,24 @@ if [[ -f $profile ]] && jq -e '[.extends] | flatten | any(. == "oalders-ansible"
     echo "🗯️nn: ansible mixin — ANSIBLE_LOCAL_TEMP=$ansible_local_tmp" >&2
 fi
 
+# Buildx keeps its state (builder instances, the current-builder pointer) under
+# ~/.docker/buildx by default. Granting that home path for write is a channel
+# out of the sandbox: a compromised session could persist a remote-driver
+# builder aimed at an attacker endpoint and mark it current, and a later
+# un-sandboxed `docker buildx build` on the host would ship its build context
+# there — a compromise that outlives the worktree (#1004). Redirect the state
+# into the worktree-local .tmp (covered by --allow-cwd, so no home write grant)
+# instead; the only trade-off is that builders no longer persist across
+# worktrees, matching the accepted trade-off for serena's memories. Gated on the
+# resolved profile structurally listing oalders-docker in its extends, same
+# shape as the ansible redirect above.
+docker_env=()
+if [[ -f $profile ]] && jq -e '[.extends] | flatten | any(. == "oalders-docker")' "$profile" >/dev/null 2>&1; then
+    buildx_config="$PWD/.tmp/buildx"
+    docker_env=("BUILDX_CONFIG=$buildx_config")
+    echo "🗯️nn: docker mixin — BUILDX_CONFIG=$buildx_config" >&2
+fi
+
 # Opt-in clodhopper wiring. clodhopper init --local writes the hooks into
 # .claude/settings.local.json (gitignored). --settings adds a settings source;
 # it doesn't replace the project hierarchy, so claude still loads
@@ -477,5 +495,6 @@ exec nono run --profile "$profile" --allow-cwd --workdir . \
     "${chrome_env[@]+"${chrome_env[@]}"}" \
     "${hugo_env[@]+"${hugo_env[@]}"}" \
     "${ansible_env[@]+"${ansible_env[@]}"}" \
+    "${docker_env[@]+"${docker_env[@]}"}" \
     claude --settings "$session_settings" \
     --dangerously-skip-permissions "$@" "${auto_prompt[@]+"${auto_prompt[@]}"}"

--- a/nono/CLAUDE.md
+++ b/nono/CLAUDE.md
@@ -53,7 +53,7 @@ These are global infrastructure — MCP servers Claude relies on, and their runt
 | `oalders-perl`  | `cpanfile`, `Makefile.PL`, `dist.ini` | plenv (`~/.plenv`), local::lib (`~/perl5`), Dist::Zilla (`~/.dzil`, `~/dot-files/dzil`), prove (`~/.proverc`), XS system C headers (`/usr/include`, `/usr/local/include`). Net-free; CPAN/MetaCPAN/MagPie network is in the paired `oalders-perl-net` (appended alongside it by `nn`). |
 | `oalders-node`  | `package.json`                        | `*.npmjs.org`, `registry.npmjs.org` (npm registry network access for installs)     |
 | `oalders-go`    | `go.mod`                              | Go toolchain (`go_runtime` group), build/module/lint caches (`~/.cache/go-build`, `~/.cache/golangci-lint`, `~/go/pkg/mod`), module proxy + checksum DB (`proxy.golang.org`, `sum.golang.org`), and cgo system headers (`/usr/include`, `/usr/local/include`, `/opt/homebrew/include`, pkg-config dirs, `/Library/Developer/CommandLineTools`) |
-| `oalders-docker` | `docker-compose.yml` / `docker-compose.yaml` / `compose.yml` / `compose.yaml` | `/usr/libexec/docker/cli-plugins` (read) — the actual fix for #1002 and the **only load-bearing grant** in the mixin: `docker compose` and `docker buildx` are CLI *plugins* (standalone binaries in that dir), not subcommands of the `docker` binary, so without this read they fail with `docker: unknown command` while plain `docker` works. `~/.docker` is deliberately narrowed to `contexts/` (read), `buildx/` (write — buildx persists builder state), and `config.json` (read) rather than a directory-wide read; `config.json` is duplicated from `oalders-core` so the sibling stands alone. Both `/var/run/docker.sock` and `/run/docker.sock` (`allow_file`) are **defensive only** — see below. Net-free: image pulls are done by the daemon, which runs **outside** the sandbox, so nothing traverses the session proxy. A bare `Dockerfile` is deliberately **not** a marker. |
+| `oalders-docker` | `docker-compose.yml` / `docker-compose.yaml` / `compose.yml` / `compose.yaml` | `/usr/libexec/docker/cli-plugins` (read) — the actual fix for #1002 and the **only load-bearing grant** in the mixin: `docker compose` and `docker buildx` are CLI *plugins* (standalone binaries in that dir), not subcommands of the `docker` binary, so without this read they fail with `docker: unknown command` while plain `docker` works. `~/.docker` is deliberately narrowed to `contexts/` (read) and `config.json` (read) rather than a directory-wide read, and no `~/.docker` path is granted for write; `config.json` is duplicated from `oalders-core` so the sibling stands alone. Buildx state, which used to need `buildx/` (write), is redirected into the worktree via `BUILDX_CONFIG` in `bin/nn` (#1004) — see the blast-radius note below. Both `/var/run/docker.sock` and `/run/docker.sock` (`allow_file`) are **defensive only** — see below. Net-free: image pulls are done by the daemon, which runs **outside** the sandbox, so nothing traverses the session proxy. A bare `Dockerfile` is deliberately **not** a marker. |
 | `oalders-hugo`  | `hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` + `themes/` | Hugo cache (`~/.cache/hugo_cache`). When Hugo matches, `nn` also appends `oalders-snap` to the mixin list because Hugo on Linux is typically snap-installed, and — if the host is on a tailnet — opens Hugo's serve ports over the tailscale IP (see §2c). |
 | `oalders-snap`  | (no markers of its own — `nn` appends it alongside any snap-backed sibling like `oalders-hugo`) | Reads for snap-confined binaries: `/snap`, `/var/lib/snapd`, `/etc/fstab` (snapd's startup checks parse the mount table). |
 
@@ -108,18 +108,23 @@ none of them fixable in a profile. A corollary worth carrying beyond Docker:
 verdict is unreliable for sockets, FIFOs, and device nodes. Verify those
 empirically rather than trusting the check.
 
-**The one grant with a host-side blast radius is `~/.docker/buildx` (write).**
-It is load-bearing (`docker buildx create` can't persist a builder without it)
-and it is the mixin's only write that outlives the session. A session can
-persist a `remote`-driver builder pointing at an endpoint it chooses and mark
-it current; a later **un-sandboxed** `docker buildx build` on the host then
-ships that build context — source, `.env` files — to the endpoint. Note the
-asymmetry with `~/.docker/contexts`, kept read-only for exactly this reason.
-Accepted for now and tracked in #1004, which proposes redirecting it to
-`BUILDX_CONFIG="$PWD/.tmp/buildx"` the way `bin/nn` already redirects
-`SERENA_HOME` and `ANSIBLE_LOCAL_TEMP`. Low priority only because #1003 means
-host root is reachable anyway — this is not the weakest link, just the one
-that survives worktree deletion.
+**Buildx state is redirected out of `~/.docker`, not granted there (#1004).**
+Buildx keeps its builder instances and current-builder pointer under
+`~/.docker/buildx` by default, and granting that home path for write would be
+the mixin's only write to outlive the session — a host-side blast radius. A
+session could persist a `remote`-driver builder pointing at an endpoint it
+chooses and mark it current; a later **un-sandboxed** `docker buildx build` on
+the host would then ship that build context — source, `.env` files — to the
+endpoint, surviving deletion of the worktree that created it. Note the
+asymmetry it would create with `~/.docker/contexts`, kept read-only for exactly
+this reason. So `bin/nn` exports `BUILDX_CONFIG="$PWD/.tmp/buildx"` whenever the
+resolved profile lists `oalders-docker` in its `extends` — the same redirect it
+already does for `SERENA_HOME` and `ANSIBLE_LOCAL_TEMP` — and the profile grants
+no `~/.docker` write at all. The `.tmp` target is covered by `--allow-cwd`, so
+no new grant is needed; the only trade-off is that builders no longer persist
+across worktrees, matching the accepted trade-off for serena's memories. This
+was low priority (per #1003 host root is reachable anyway, so it was never the
+weakest link) but is cheap, correct hygiene now done.
 
 **Which is why detection is automatic.** Keying on compose files rather than
 making the mixin opt-in costs no containment: the escape is already universal,

--- a/nono/oalders-docker.json
+++ b/nono/oalders-docker.json
@@ -1,15 +1,12 @@
 {
   "meta": {
     "name": "oalders-docker",
-    "description": "Docker CLI mixin: the CLI plugins dir (/usr/libexec/docker/cli-plugins — where `docker compose` and `docker buildx` actually live) plus a narrow slice of ~/.docker (contexts, buildx state, config.json). The two daemon socket allow_file entries are defensive only: Landlock mediates path open(), not connect(AF_UNIX), so the daemon is reachable from any session regardless of profile. Net-free: image pulls run in the daemon outside the sandbox, so nothing traverses the session proxy."
+    "description": "Docker CLI mixin: the CLI plugins dir (/usr/libexec/docker/cli-plugins — where `docker compose` and `docker buildx` actually live) plus a narrow read-only slice of ~/.docker (contexts, config.json). No home path is granted for write: buildx state is redirected into the worktree via BUILDX_CONFIG in bin/nn (#1004), so the mixin has no write that outlives the session. The two daemon socket allow_file entries are defensive only: Landlock mediates path open(), not connect(AF_UNIX), so the daemon is reachable from any session regardless of profile. Net-free: image pulls run in the daemon outside the sandbox, so nothing traverses the session proxy."
   },
   "filesystem": {
     "read": [
       "/usr/libexec/docker/cli-plugins",
       "~/.docker/contexts"
-    ],
-    "allow": [
-      "~/.docker/buildx"
     ],
     "read_file": [
       "~/.docker/config.json"

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -508,6 +508,43 @@ setup() {
     ! grep -Fq -- "ANSIBLE_LOCAL_TEMP=" "$BATS_TEST_TMPDIR/nono-argv"
 }
 
+@test "bin/nn points buildx state at the worktree-local .tmp" {
+    # Buildx defaults its state to ~/.docker/buildx; granting that home path for
+    # write was a channel out of the sandbox (a persisted remote-driver builder
+    # picked up by a later un-sandboxed host build). When the resolved profile
+    # lists oalders-docker in its extends, nn redirects the state to the
+    # worktree-local .tmp (covered by --allow-cwd, so no home write grant) and
+    # the profile no longer grants ~/.docker/buildx (#1004).
+    mkdir -p .nono
+    echo '{"extends": ["oalders", "oalders-docker"]}' >.nono/profile.json
+    run "$NN"
+    [ "$status" -eq 0 ]
+    grep -Fxq -- "BUILDX_CONFIG=$BATS_TEST_TMPDIR/work/.tmp/buildx" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn sets no BUILDX_CONFIG for a non-docker profile" {
+    # The redirect is scoped to profiles that actually compose oalders-docker; a
+    # plain session must not carry the docker-specific env var. (The clean test
+    # cwd resolves to the bare oalders profile, which doesn't pull it in.)
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # Guard against a vacuous pass on a missing argv dump.
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
+    ! grep -Fq -- "BUILDX_CONFIG=" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
+@test "bin/nn does not trip the buildx redirect on a substring-only match" {
+    # The gate inspects the extends array structurally (jq), not as a raw
+    # substring, so a profile that merely contains the string "oalders-docker"
+    # as part of a differently-named entry must NOT trigger the redirect.
+    mkdir -p .nono
+    echo '{"extends": ["oalders", "oalders-docker-experimental"]}' >.nono/profile.json
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
+    ! grep -Fq -- "BUILDX_CONFIG=" "$BATS_TEST_TMPDIR/nono-argv"
+}
+
 # bin/nn checks four compose filenames; cover each so dropping one from the
 # marker list can't pass unnoticed. A compose file at the repo top means the
 # session will run `docker compose`, which needs the CLI plugins dir the

--- a/test/nono-profiles.bats
+++ b/test/nono-profiles.bats
@@ -188,16 +188,30 @@ SYMLINKS="$SCRIPT_DIR/installer/symlinks.sh"
     done
 }
 
-# Buildx writes its own state (builder instances, metadata) under
-# ~/.docker/buildx, so that path needs write, not just read (#1002).
-@test "oalders-docker.json grants ~/.docker/buildx for write" {
-    run jq -e '.filesystem.allow | any(. == "~/.docker/buildx")' "$NONO_DIR/oalders-docker.json"
+# Buildx state is deliberately NOT granted at the home path anymore. Granting
+# ~/.docker/buildx for write was a channel out of the sandbox: a session could
+# persist a remote-driver builder aimed at an attacker endpoint and a later
+# un-sandboxed `docker buildx build` on the host would ship its build context
+# there, surviving worktree deletion. bin/nn redirects the state into the
+# worktree via BUILDX_CONFIG instead (#1004; see the nn.bats redirect test).
+@test "oalders-docker.json does not grant ~/.docker/buildx (redirected via BUILDX_CONFIG)" {
+    # Parse first so a vanished profile fails loudly rather than passing vacuously.
+    run jq empty "$NONO_DIR/oalders-docker.json"
     [ "$status" -eq 0 ]
+    # Reject the path under any write-granting key, in either ~ or $HOME spelling.
+    run jq -e '
+        [.filesystem.allow[]?, .filesystem.allow_file[]?,
+         .filesystem.bypass_protection[]?]
+        | any(. == "~/.docker/buildx" or . == "$HOME/.docker/buildx")
+    ' "$NONO_DIR/oalders-docker.json"
+    # jq -e exits non-zero when the result is false/null: that is the pass.
+    [ "$status" -ne 0 ]
 }
 
-# ~/.docker is deliberately narrowed to contexts/, buildx/, and config.json
-# rather than a directory-wide read: the tree can also hold credential
-# helper output and other daemon/registry state (#1002).
+# ~/.docker is deliberately narrowed to contexts/ and config.json rather than a
+# directory-wide read: the tree can also hold credential helper output and other
+# daemon/registry state (#1002). Buildx state used to sit here too but is now
+# redirected to the worktree (#1004).
 @test "oalders-docker.json does not grant the whole ~/.docker dir" {
     # Parse first — see the /usr/libexec guard above for why.
     run jq empty "$NONO_DIR/oalders-docker.json"


### PR DESCRIPTION
Closes #1004

## Problem

The `oalders-docker` nono mixin granted `~/.docker/buildx` for write so buildx
could persist builder state. That was the mixin only write outside the worktree
and a channel out of the sandbox: a compromised or prompt-injected session could
plant a `remote`-driver builder pointing at an attacker BuildKit endpoint and
mark it current, and a later un-sandboxed `docker buildx build` on the host would
ship its build context there — surviving deletion of the worktree that created
it. It was also inconsistent with the neighbouring `~/.docker/contexts`, kept
read-only for exactly this reason.

## Changes

- `bin/nn`: export `BUILDX_CONFIG=$PWD/.tmp/buildx` when the resolved profile
  lists `oalders-docker` in its `extends`, mirroring the existing
  `ANSIBLE_LOCAL_TEMP` / `SERENA_HOME` redirects. `.tmp` is covered by
  `--allow-cwd`, so no new grant is needed.
- `nono/oalders-docker.json`: drop the `~/.docker/buildx` write grant entirely;
  the profile now grants no writable home path.
- `nono/CLAUDE.md`: update the sibling table row and the blast-radius note to
  describe the implemented redirect.
- Tests: `test/nn.bats` gains positive / non-docker-negative / substring-guard
  cases for the redirect; `test/nono-profiles.bats` flips the buildx grant test
  into a guard that the home path is no longer granted.

Trade-off: builders no longer persist across worktrees, matching the accepted
trade-off already made for serena memories.

## Testing

- `bats test/` — full suite passes (exit 0).
- `precious lint bin/nn` — clean.
- Verified the profile grants zero writable `~/.docker` paths and that
  `BUILDX_CONFIG` is wired into the launch.
- General + security code review (fanned out via /code-review-intense-flow):
  no Critical or Important findings; security review confirms the persistence
  channel is closed by the grant removal (defense-in-depth, independent of the
  env plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 4.8