### PR TITLE
Sweep leaked compose networks in docker-teardown

### DIFF
--- a/bin/docker-teardown
+++ b/bin/docker-teardown
@@ -5,7 +5,8 @@
 # Given a worktree path (and optionally its branch), removes the docker
 # containers that provably belong to that worktree: the `bin/dev` container
 # for the worktree+branch, and any `docker compose` containers whose project
-# working directory is at or under the worktree. Session volumes are kept.
+# working directory is at or under the worktree. Session volumes are kept. It
+# then sweeps the worktree's empty compose networks (see "network sweep").
 #
 # It then reclaims ownership of files those containers wrote into the worktree
 # as root (bind-mounted data dirs — see "ownership reclaim" below).
@@ -26,6 +27,26 @@
 # Ad-hoc `docker run` containers carry no such handle and are left alone
 # (with a note), matching the "minimize false positives" bias of the other
 # teardown helpers.
+#
+# Compose networks are swept too, but held to the same provable-ownership bar.
+# A network is removed only when BOTH hold: (a) its
+# `com.docker.compose.project` label matches a project this worktree owns —
+# either a project name derived from a container matched above, or the compose
+# default project (the worktree dir basename, normalized as compose stores it)
+# — AND (b) it has zero attached containers. The zero-attachment guard keeps a
+# network shared/in-use by another worktree safe, and makes re-runs a no-op.
+#
+# Networks are removed where session volumes are KEPT, and that asymmetry is
+# deliberate: a compose network is cheap to recreate (the next `compose up`
+# rebuilds `<project>_default`), whereas a session volume holds state (bin/dev's
+# Claude history) that no `up` would bring back. Leaked empty networks are also
+# a real hazard — they accumulate until docker's default address pool is
+# subnetted out and `compose up` fails everywhere with "all predefined address
+# pools have been fully subnetted".
+#
+# NOTE: a bare `docker network prune` is NOT the fix. It would also delete empty
+# hand-created `external:` networks, which compose does NOT recreate. This
+# targeted, label-scoped sweep touches only this worktree's own networks.
 
 set -u
 
@@ -36,6 +57,10 @@ Usage: docker-teardown [-n|--dry-run] WORKTREE_PATH [BRANCH]
 Removes docker containers that belong to WORKTREE_PATH: the bin/dev
 container for WORKTREE_PATH+BRANCH and any docker-compose containers whose
 project working_dir is at or under WORKTREE_PATH. Session volumes are kept.
+
+Then removes this worktree's empty compose networks (those labelled with a
+project it owns and with zero attached containers); networks, unlike
+volumes, are cheap for compose to recreate on the next `up`.
 
 Then chowns back any path under WORKTREE_PATH that a container wrote as
 root, so `git worktree remove` can delete the tree.
@@ -100,15 +125,20 @@ targets=""
 # value is $wt or a path beneath it. `-a` so stopped-but-lingering containers
 # are caught too. The tab-delimited format keeps ID and label value paired.
 wd_label="com.docker.compose.project.working_dir"
-while IFS=$'\t' read -r id wd; do
+proj_label="com.docker.compose.project"
+# Compose project names collected from matched containers. These are provably
+# this worktree's and seed the network sweep further down.
+compose_projects=""
+while IFS=$'\t' read -r id wd proj; do
     [ -n "$id" ] || continue
     case "$wd" in
     "$wt" | "$wt"/*)
         targets="$targets $id"
+        [ -n "$proj" ] && compose_projects="$compose_projects $proj"
         ;;
     esac
 done < <(docker ps -a --filter "label=$wd_label" \
-    --format "{{.ID}}"$'\t'"{{.Label \"$wd_label\"}}" 2>/dev/null)
+    --format "{{.ID}}"$'\t'"{{.Label \"$wd_label\"}}"$'\t'"{{.Label \"$proj_label\"}}" 2>/dev/null)
 
 # Source 2 — the bin/dev container for this worktree+branch. bin/dev names it
 # `<repo>-<branch>` where repo is the worktree dir basename and branch has
@@ -146,6 +176,60 @@ else
         # runs once.
         if ! printf '%s\n' "$targets" | xargs docker rm -f >/dev/null 2>&1; then
             echo "docker-teardown: warning: one or more containers could not be removed" >&2
+        fi
+    fi
+fi
+
+# --- compose network sweep -----------------------------------------------
+#
+# Runs regardless of whether any containers matched above: the real leak is a
+# `<project>_default` network whose containers are long gone, so there is
+# nothing for Source 1/2 to find — only the network survives. Candidate project
+# names come from two sources: the labels of the containers matched above
+# (provably ours), and the compose default project name inferred from the
+# worktree dir basename (normalized the way compose stores it: lowercased, with
+# characters outside [a-z0-9_-] dropped). A network is removed only if it has
+# zero attached containers, so an in-use network is never touched and re-runs
+# are no-ops. Networks are kept in their own pipeline, never folded into
+# $targets (whose grep filters to hex container IDs).
+proj_fallback="$(basename "$wt" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
+
+# Dedup the candidate project names from both sources.
+candidate_projects="$(printf '%s\n' $compose_projects "$proj_fallback" \
+    | grep -v '^$' | sort -u)"
+
+# Collect removable networks as "<id><TAB><name>" lines: labelled with a
+# candidate project AND carrying zero attached containers.
+net_targets=""
+while IFS= read -r proj; do
+    [ -n "$proj" ] || continue
+    while IFS=$'\t' read -r net_id net_name; do
+        [ -n "$net_id" ] || continue
+        attached="$(docker network inspect "$net_id" \
+            --format '{{len .Containers}}' 2>/dev/null)"
+        [ "$attached" = 0 ] || continue
+        net_targets="$net_targets$net_id"$'\t'"$net_name"$'\n'
+    done < <(docker network ls \
+        --filter "label=com.docker.compose.project=$proj" \
+        --format '{{.ID}}'$'\t''{{.Name}}' 2>/dev/null)
+done <<<"$candidate_projects"
+
+net_targets="$(printf '%s' "$net_targets" | grep -v '^$' | sort -u)"
+
+if [ -n "$net_targets" ]; then
+    net_count="$(printf '%s\n' "$net_targets" | wc -l | tr -d ' ')"
+    if [ "$dry" = 1 ]; then
+        echo "docker-teardown: DRY RUN - would remove $net_count network(s) owned by $wt:"
+        while IFS=$'\t' read -r net_id net_name; do
+            echo "  $net_id  $net_name"
+        done <<<"$net_targets"
+    else
+        echo "docker-teardown: removing $net_count network(s) owned by $wt"
+        # There is no `-f` for network rm; the zero-attachment guard above
+        # already ensures nothing is attached. Warn (don't abort) on failure.
+        net_ids="$(printf '%s\n' "$net_targets" | cut -f1)"
+        if ! printf '%s\n' "$net_ids" | xargs docker network rm >/dev/null 2>&1; then
+            echo "docker-teardown: warning: one or more networks could not be removed" >&2
         fi
     fi
 fi

--- a/bin/docker-teardown
+++ b/bin/docker-teardown
@@ -36,7 +36,15 @@
 # — AND (b) it has zero attached containers. The zero-attachment guard keeps a
 # network shared/in-use by another worktree safe, and makes re-runs a no-op.
 #
-# Networks are removed where session volumes are KEPT, and that asymmetry is
+# Same-basename collision (deliberate, bounded tradeoff): two worktrees sharing
+# a dir basename — the same repo checked out twice, or the same basename across
+# different repos — resolve to the SAME compose default project name, so a
+# teardown of one may sweep a network the sibling worktree also uses. The
+# zero-attachment guard bounds this: only an EMPTY network is ever removed, and
+# compose recreates `<project>_default` on the sibling's next `up`. Nothing
+# in use is touched.
+#
+# Networks are removed, whereas session volumes are KEPT, and that asymmetry is
 # deliberate: a compose network is cheap to recreate (the next `compose up`
 # rebuilds `<project>_default`), whereas a session volume holds state (bin/dev's
 # Claude history) that no `up` would bring back. Leaked empty networks are also
@@ -194,9 +202,13 @@ fi
 # $targets (whose grep filters to hex container IDs).
 proj_fallback="$(basename "$wt" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
 
-# Dedup the candidate project names from both sources.
+# Dedup the candidate project names from both sources. $compose_projects is
+# left unquoted on purpose so it word-splits into separate names; disable glob
+# expansion around it so a name can never be expanded as a pathname pattern.
+set -f
 candidate_projects="$(printf '%s\n' $compose_projects "$proj_fallback" \
     | grep -v '^$' | sort -u)"
+set +f
 
 # Collect removable networks as "<id><TAB><name>" lines: labelled with a
 # candidate project AND carrying zero attached containers.
@@ -227,7 +239,9 @@ if [ -n "$net_targets" ]; then
         echo "docker-teardown: removing $net_count network(s) owned by $wt"
         # There is no `-f` for network rm; the zero-attachment guard above
         # already ensures nothing is attached. Warn (don't abort) on failure.
-        net_ids="$(printf '%s\n' "$net_targets" | cut -f1)"
+        # The `^[0-9a-f]+$` allowlist mirrors the container path: only real
+        # docker IDs (lowercase hex) reach `docker network rm`.
+        net_ids="$(printf '%s\n' "$net_targets" | cut -f1 | grep -E '^[0-9a-f]+$')"
         if ! printf '%s\n' "$net_ids" | xargs docker network rm >/dev/null 2>&1; then
             echo "docker-teardown: warning: one or more networks could not be removed" >&2
         fi

--- a/test/docker-teardown.bats
+++ b/test/docker-teardown.bats
@@ -287,21 +287,21 @@ exit 0"
 @test "network sweep removes a stale empty network for the worktree basename" {
     nets="$BATS_TEST_TMPDIR/nets"
     # basename of WT is "wt"; compose's default project would be "wt".
-    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    printf 'wt\taaa111\twt_default\n' >"$nets"
     export DOCKER_NETWORK_ROWS="$nets"
 
     run "$DT" "$WT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"removing 1 network(s)"* ]]
-    [[ "$(cat "$NETRM_LOG")" == *net-aaa* ]]
+    [[ "$(cat "$NETRM_LOG")" == *aaa111* ]]
 }
 
 @test "network sweep leaves a network that still has attached containers" {
     nets="$BATS_TEST_TMPDIR/nets"
-    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    printf 'wt\taaa111\twt_default\n' >"$nets"
     export DOCKER_NETWORK_ROWS="$nets"
     attached="$BATS_TEST_TMPDIR/attached"
-    printf 'net-aaa\t2\n' >"$attached"
+    printf 'aaa111\t2\n' >"$attached"
     export DOCKER_NETWORK_ATTACHED="$attached"
 
     run "$DT" "$WT"
@@ -316,23 +316,23 @@ exit 0"
     printf 'aaa111\t%s\tmyproj\n' "$WT" >"$rows"
     export DOCKER_COMPOSE_ROWS="$rows"
     nets="$BATS_TEST_TMPDIR/nets"
-    printf 'myproj\tnet-bbb\tmyproj_default\n' >"$nets"
+    printf 'myproj\tbbb222\tmyproj_default\n' >"$nets"
     export DOCKER_NETWORK_ROWS="$nets"
 
     run "$DT" "$WT"
     [ "$status" -eq 0 ]
-    [[ "$(cat "$NETRM_LOG")" == *net-bbb* ]]
+    [[ "$(cat "$NETRM_LOG")" == *bbb222* ]]
 }
 
 @test "network sweep dry-run lists the network but removes nothing" {
     nets="$BATS_TEST_TMPDIR/nets"
-    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    printf 'wt\taaa111\twt_default\n' >"$nets"
     export DOCKER_NETWORK_ROWS="$nets"
 
     run "$DT" --dry-run "$WT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"DRY RUN - would remove 1 network(s)"* ]]
-    [[ "$output" == *"net-aaa  wt_default"* ]]
+    [[ "$output" == *"aaa111  wt_default"* ]]
     [ ! -s "$NETRM_LOG" ]
 }
 
@@ -340,4 +340,48 @@ exit 0"
     run "$DT" "$WT"
     [ "$status" -eq 0 ]
     [ ! -s "$NETRM_LOG" ]
+}
+
+@test "network sweep removes multiple networks in a single run" {
+    rows="$BATS_TEST_TMPDIR/rows"
+    # A matched container contributes a second project, so two distinct
+    # projects each own one empty network.
+    printf 'aaa111\t%s\tmyproj\n' "$WT" >"$rows"
+    export DOCKER_COMPOSE_ROWS="$rows"
+    nets="$BATS_TEST_TMPDIR/nets"
+    printf 'wt\taaa111\twt_default\n' >"$nets"
+    printf 'myproj\tbbb222\tmyproj_default\n' >>"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"removing 2 network(s)"* ]]
+    removed="$(cat "$NETRM_LOG")"
+    [[ "$removed" == *aaa111* ]]
+    [[ "$removed" == *bbb222* ]]
+}
+
+@test "network sweep: a failed network rm warns but still exits 0" {
+    nets="$BATS_TEST_TMPDIR/nets"
+    printf 'wt\taaa111\twt_default\n' >"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+    # Re-stub docker so only `network rm` fails; the network ls/inspect queries
+    # still succeed so a target is found and removal is attempted.
+    stub_command docker "case \"\${1:-}\" in
+ps) exit 0 ;;
+image) exit 0 ;;
+run) exit 0 ;;
+network)
+    case \"\${2:-}\" in
+    ls) printf 'aaa111\twt_default\n'; exit 0 ;;
+    inspect) echo 0; exit 0 ;;
+    rm) exit 1 ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0"
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"one or more networks could not be removed"* ]]
 }

--- a/test/docker-teardown.bats
+++ b/test/docker-teardown.bats
@@ -15,6 +15,14 @@ load 'helpers.bash'
 #                         the reclaim step finds a local image.
 #   DOCKER_RUN_LOG        file the stub appends `run` arguments to, so a test
 #                         can assert how the ownership-reclaim container ran.
+#   DOCKER_NETWORK_ROWS   file of "<project><TAB><id><TAB><name>" lines; the
+#                         `network ls` query emits the id/name of rows whose
+#                         project matches the requested label filter.
+#   DOCKER_NETWORK_ATTACHED file of "<id><TAB><count>" lines giving the
+#                         attached-container count `network inspect` reports for
+#                         a network; a network absent from the file counts 0.
+#   DOCKER_NETRM_LOG      file the stub appends `network rm` arguments to, so a
+#                         test can assert which networks were removed.
 docker_stub_body='
 case "${1:-}" in
 ps)
@@ -64,6 +72,53 @@ run)
     printf "%s\n" "$*" >>"${DOCKER_RUN_LOG:?}"
     exit 0
     ;;
+network)
+    shift
+    case "${1:-}" in
+    ls)
+        shift
+        proj=""
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+            --filter)
+                shift
+                case "$1" in
+                label=com.docker.compose.project=*)
+                    proj="${1#label=com.docker.compose.project=}"
+                    ;;
+                esac
+                ;;
+            --format) shift ;;
+            esac
+            shift
+        done
+        if [ -f "${DOCKER_NETWORK_ROWS:-/nonexistent}" ]; then
+            while IFS="$(printf "\t")" read -r p id name; do
+                [ "$p" = "$proj" ] && printf "%s\t%s\n" "$id" "$name"
+            done <"$DOCKER_NETWORK_ROWS"
+        fi
+        exit 0
+        ;;
+    inspect)
+        shift
+        net="$1"
+        count=0
+        if [ -f "${DOCKER_NETWORK_ATTACHED:-/nonexistent}" ]; then
+            while IFS="$(printf "\t")" read -r n c; do
+                [ "$n" = "$net" ] && count="$c"
+            done <"$DOCKER_NETWORK_ATTACHED"
+        fi
+        echo "$count"
+        exit 0
+        ;;
+    rm)
+        shift
+        printf "%s\n" "$*" >>"${DOCKER_NETRM_LOG:?}"
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
 esac
 exit 0
 '
@@ -80,6 +135,9 @@ setup() {
     RUN_LOG="$BATS_TEST_TMPDIR/run.log"
     : >"$RUN_LOG"
     export DOCKER_RUN_LOG="$RUN_LOG"
+    NETRM_LOG="$BATS_TEST_TMPDIR/netrm.log"
+    : >"$NETRM_LOG"
+    export DOCKER_NETRM_LOG="$NETRM_LOG"
     stub_command docker "$docker_stub_body"
 }
 
@@ -208,10 +266,78 @@ make_real_worktree() {
 ps) exit 0 ;;
 image) exit 0 ;;
 run) exit 1 ;;
+network) exit 0 ;;
 esac
 exit 0"
     run "$DT" "$WT" feature
     # Teardown must never block worktree removal on docker.
     [ "$status" -eq 0 ]
     [[ "$output" == *"could not reclaim"* ]]
+}
+
+# --- compose network sweep -----------------------------------------------
+#
+# The real leak: containers are gone but a `<basename>_default` network with
+# zero attachments survives. The sweep infers the compose project name from the
+# worktree basename ("wt" here) and removes the empty network. Guard: a network
+# with an attached container is left alone. It also honours project names
+# derived from matched containers, mirrors the container dry-run style, and is a
+# no-op when nothing matches.
+
+@test "network sweep removes a stale empty network for the worktree basename" {
+    nets="$BATS_TEST_TMPDIR/nets"
+    # basename of WT is "wt"; compose's default project would be "wt".
+    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"removing 1 network(s)"* ]]
+    [[ "$(cat "$NETRM_LOG")" == *net-aaa* ]]
+}
+
+@test "network sweep leaves a network that still has attached containers" {
+    nets="$BATS_TEST_TMPDIR/nets"
+    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+    attached="$BATS_TEST_TMPDIR/attached"
+    printf 'net-aaa\t2\n' >"$attached"
+    export DOCKER_NETWORK_ATTACHED="$attached"
+
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [ ! -s "$NETRM_LOG" ]
+}
+
+@test "network sweep removes a network derived from a matched container's project" {
+    rows="$BATS_TEST_TMPDIR/rows"
+    # A matched container carrying a compose project label whose value differs
+    # from the worktree basename.
+    printf 'aaa111\t%s\tmyproj\n' "$WT" >"$rows"
+    export DOCKER_COMPOSE_ROWS="$rows"
+    nets="$BATS_TEST_TMPDIR/nets"
+    printf 'myproj\tnet-bbb\tmyproj_default\n' >"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$NETRM_LOG")" == *net-bbb* ]]
+}
+
+@test "network sweep dry-run lists the network but removes nothing" {
+    nets="$BATS_TEST_TMPDIR/nets"
+    printf 'wt\tnet-aaa\twt_default\n' >"$nets"
+    export DOCKER_NETWORK_ROWS="$nets"
+
+    run "$DT" --dry-run "$WT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY RUN - would remove 1 network(s)"* ]]
+    [[ "$output" == *"net-aaa  wt_default"* ]]
+    [ ! -s "$NETRM_LOG" ]
+}
+
+@test "network sweep is a no-op when no networks match" {
+    run "$DT" "$WT"
+    [ "$status" -eq 0 ]
+    [ ! -s "$NETRM_LOG" ]
 }


### PR DESCRIPTION
Closes #1010

## Problem

`bin/docker-teardown` removed containers but never removed compose `<project>_default` networks. Merged/removed worktrees left empty bridge networks behind until Dockers default address pool exhausted, at which point `docker compose up` failed in every worktree with "all predefined address pools have been fully subnetted".

## Changes

- `bin/docker-teardown`: added a compose-network sweep that runs after container removal (crucially, even when no containers matched — the actual leak case). Candidate compose project names come from two sources: the `com.docker.compose.project` label of containers already matched by the working_dir rule (provable), plus a normalized `basename "$wt"` fallback (mirrors the existing bin/dev name inference). A network is removed only if it has zero attached containers, which keeps the minimize-false-positives bias, makes re-runs idempotent, and is re-enforced by dockers own refusal to remove in-use networks.
- Dry-run reports the networks it would remove in the existing output style and removes nothing.
- Header comment documents why networks are safe to sweep (cheap to recreate) whereas session volumes are kept, warns that a bare `docker network prune` is unsafe (it also removes empty external networks), and notes the same-basename collision tradeoff.
- Hardening from code review: scoped the intentional word-split in `set -f`/`set +f` to block glob expansion, and applied the same `^[0-9a-f]+$` hex allowlist to network IDs that the container path already uses.
- `bin/merge-pr` and `bin/remove-worktree` are unchanged; they call the same helper and inherit the fix.

## Testing

- Extended `test/docker-teardown.bats` with cases for: stale-network removal (no containers), the zero-attachment guard, container-label-derived project names, dry-run reporting-only, no-op on a clean worktree, multi-network removal, and the `docker network rm` failure/warning branch.
- Full suite: `bats test/` → 150 tests, 0 failures. `bash -n bin/docker-teardown` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 4.8