### PR TITLE
add-worktree: drop the main checkout settings.local.json before creating a worktree

### DIFF
--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -112,6 +112,14 @@ if [[ -f scripts/init.sh ]]; then
     ./scripts/init.sh
 fi
 
+# Claude Code sessions started from a worktree walk over to the main checkout
+# and try to read its .claude/settings.local.json, which the sandbox can't
+# open — so every session opens with an EACCES warning. Upstream considers
+# that working as intended (anthropics/claude-code#77998). The file is
+# machine-local and gitignored, and the main checkout is only ever a source
+# for worktrees, so discarding its approved permissions costs nothing.
+rm -f "$repo_root/.claude/settings.local.json"
+
 if [[ -n $(pgrep tmux) ]]; then
     . ~/dot-files/bash_functions.sh
 

--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -51,11 +51,14 @@ repo_name="$(basename "$repo_root")"
 # machine-local and gitignored, and the main checkout is only ever a source
 # for worktrees, so discarding its approved permissions costs nothing. Done
 # here, before anything that can fail under `set -e`, so a worktree never
-# gets created without the cleanup having run.
+# gets created without the cleanup having run. This is point-in-time, not
+# durable: a later Claude session run in the main checkout recreates the
+# file, and existing worktrees warn again until the next add-worktree.
 if [[ -f "$repo_root/.claude/settings.local.json" ]]; then
     echo "Removing $repo_root/.claude/settings.local.json (see anthropics/claude-code#77998)" >&2
     rm -f "$repo_root/.claude/settings.local.json"
 fi
+
 date_stamp="$(date +%Y-%m-%d)"
 
 all_worktrees="$HOME/.worktree/$repo_name/$date_stamp"

--- a/bin/add-worktree
+++ b/bin/add-worktree
@@ -43,6 +43,19 @@ cd "$git_dir/.." || exit 1
 
 repo_root="$(pwd)"
 repo_name="$(basename "$repo_root")"
+
+# Claude Code sessions started from a worktree walk over to the main checkout
+# and try to read its .claude/settings.local.json, which the sandbox can't
+# open — so every session opens with an EACCES warning. Upstream considers
+# that working as intended (anthropics/claude-code#77998). The file is
+# machine-local and gitignored, and the main checkout is only ever a source
+# for worktrees, so discarding its approved permissions costs nothing. Done
+# here, before anything that can fail under `set -e`, so a worktree never
+# gets created without the cleanup having run.
+if [[ -f "$repo_root/.claude/settings.local.json" ]]; then
+    echo "Removing $repo_root/.claude/settings.local.json (see anthropics/claude-code#77998)" >&2
+    rm -f "$repo_root/.claude/settings.local.json"
+fi
 date_stamp="$(date +%Y-%m-%d)"
 
 all_worktrees="$HOME/.worktree/$repo_name/$date_stamp"
@@ -111,14 +124,6 @@ fi
 if [[ -f scripts/init.sh ]]; then
     ./scripts/init.sh
 fi
-
-# Claude Code sessions started from a worktree walk over to the main checkout
-# and try to read its .claude/settings.local.json, which the sandbox can't
-# open — so every session opens with an EACCES warning. Upstream considers
-# that working as intended (anthropics/claude-code#77998). The file is
-# machine-local and gitignored, and the main checkout is only ever a source
-# for worktrees, so discarding its approved permissions costs nothing.
-rm -f "$repo_root/.claude/settings.local.json"
 
 if [[ -n $(pgrep tmux) ]]; then
     . ~/dot-files/bash_functions.sh

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -172,6 +172,23 @@ exit 0'
     [ -f "$REPO_DIR/.claude/settings.json" ]
 }
 
+@test "add-worktree removes settings.local.json even when setup later fails" {
+    # The removal must happen before anything that can abort under `set -e`.
+    # scripts/init.sh failing still leaves a created worktree behind, which
+    # is exactly the session that would hit the EACCES warning.
+    setup_git_repo
+    mkdir -p "$REPO_DIR/.claude" "$REPO_DIR/scripts"
+    echo '{}' >"$REPO_DIR/.claude/settings.local.json"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$REPO_DIR/scripts/init.sh"
+    chmod +x "$REPO_DIR/scripts/init.sh"
+    git add scripts/init.sh
+    git -c commit.gpgsign=false commit -q -m "add failing init"
+
+    run "$ADD_WORKTREE" feature-branch
+    [ "$status" -ne 0 ]
+    [ ! -e "$REPO_DIR/.claude/settings.local.json" ]
+}
+
 @test "add-worktree succeeds when the main checkout has no .claude dir" {
     setup_git_repo
     [ ! -d "$REPO_DIR/.claude" ]

--- a/test/add-worktree.bats
+++ b/test/add-worktree.bats
@@ -158,6 +158,35 @@ exit 0'
     [ -f "$worktree/.tmp/fix-gh-issue.pending" ]
 }
 
+@test "add-worktree removes the main checkout's .claude/settings.local.json" {
+    setup_git_repo
+    mkdir -p "$REPO_DIR/.claude"
+    echo '{}' >"$REPO_DIR/.claude/settings.local.json"
+    echo '{}' >"$REPO_DIR/.claude/settings.json"
+
+    run "$ADD_WORKTREE" feature-branch
+    [ "$status" -eq 0 ]
+
+    [ ! -e "$REPO_DIR/.claude/settings.local.json" ]
+    # Only the machine-local file goes; shared settings stay put.
+    [ -f "$REPO_DIR/.claude/settings.json" ]
+}
+
+@test "add-worktree succeeds when the main checkout has no .claude dir" {
+    setup_git_repo
+    [ ! -d "$REPO_DIR/.claude" ]
+
+    run "$ADD_WORKTREE" feature-branch
+    [ "$status" -eq 0 ]
+
+    local date_stamp repo_name worktree
+    date_stamp="$(date +%Y-%m-%d)"
+    repo_name="$(basename "$REPO_DIR")"
+    worktree="$HOME/.worktree/$repo_name/$date_stamp/feature-branch"
+
+    [ -d "$worktree" ]
+}
+
 @test "add-worktree queues nothing for non-fix branches" {
     setup_git_repo
     run "$ADD_WORKTREE" feature-branch


### PR DESCRIPTION
Closes #1013

## Changes

- `bin/add-worktree` removes the main checkout's `.claude/settings.local.json` before creating the worktree, so sessions started there no longer open with the EACCES warning (upstream: anthropics/claude-code#77998).
- The removal happens right after `repo_root` is resolved — ahead of `gh pr checkout`, submodule init, `npm i`, and `scripts/init.sh`. Any of those failing under `set -e` would otherwise abort with the worktree already created, i.e. exactly the session the fix is meant to cover.
- The deletion is announced on stderr rather than done silently.

## Testing

- Three new cases in `test/add-worktree.bats`: the file is removed while a shared `.claude/settings.json` survives; it is still removed when a later setup step fails; and a checkout with no `.claude` dir still creates its worktree.
- Full suite: 11/11 passing. `precious lint` and `shellcheck` clean.
- Red-green verified both new behaviours: reverting the `rm` fails the first test, and moving it back below `scripts/init.sh` fails the placement test.

## Notes

- The cleanup is point-in-time. A later session run in the main checkout recreates the file, and existing worktrees warn again until the next `add-worktree`.
- The file is removed even if `git worktree add` then fails. That is the cost of running the cleanup ahead of the failure-prone steps; the file is gitignored and machine-local, so the trade seems right.

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 5
