### PR TITLE
nn: durably drop the main checkout settings.local.json on worktree launch

### DIFF
--- a/bin/nn
+++ b/bin/nn
@@ -55,6 +55,21 @@ profile=""
 profile_label=""
 project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
 
+# When launched from a worktree, drop the MAIN checkout's machine-local
+# .claude/settings.local.json so the point-in-time cleanup add-worktree does
+# (PR #1014) stays durable across every launch. Only fire from a worktree (a
+# plain main checkout must keep its own approved permissions), and only remove
+# the gitignored settings.local.json — never the shared settings.json.
+# common_dir is set only inside the block above, so guard it for `set -u`.
+if [[ -n "${common_dir-}" ]]; then
+    main_root=$(realpath -m "$common_dir/..")
+    if [[ "$main_root" != "$(realpath -m "$project_root")" &&
+        -f "$main_root/.claude/settings.local.json" ]]; then
+        echo "Removing $main_root/.claude/settings.local.json (see anthropics/claude-code#77998)" >&2
+        rm -f "$main_root/.claude/settings.local.json"
+    fi
+fi
+
 # Hugo detection, computed once and reused. Markers: modern config names
 # (hugo.toml/yaml/json), the modular config/_default/ layout, OR legacy
 # config.toml paired with themes/. The bare hugo.* names and config/_default/

--- a/bin/nn
+++ b/bin/nn
@@ -62,8 +62,8 @@ project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
 # the gitignored settings.local.json — never the shared settings.json.
 # common_dir is set only inside the block above, so guard it for `set -u`.
 if [[ -n "${common_dir-}" ]]; then
-    main_root=$(realpath -m "$common_dir/..")
-    if [[ "$main_root" != "$(realpath -m "$project_root")" &&
+    main_root=$(realpath "$common_dir/..")
+    if [[ "$main_root" != "$(realpath "$project_root")" &&
         -f "$main_root/.claude/settings.local.json" ]]; then
         echo "Removing $main_root/.claude/settings.local.json (see anthropics/claude-code#77998)" >&2
         rm -f "$main_root/.claude/settings.local.json"

--- a/test/nn.bats
+++ b/test/nn.bats
@@ -581,6 +581,63 @@ setup() {
     grep -Fq '"oalders-docker"' .nono/profile.json
 }
 
+@test "bin/nn removes the main checkout's .claude/settings.local.json from a worktree" {
+    # Launched from a worktree, nn drops the MAIN checkout's machine-local
+    # settings.local.json so add-worktree's point-in-time cleanup (PR #1014)
+    # stays durable across every launch. The shared settings.json must survive.
+    setup_git_repo
+    setup_upstream
+    mkdir -p "$REPO_DIR/.claude"
+    echo '{}' >"$REPO_DIR/.claude/settings.local.json"
+    echo '{}' >"$REPO_DIR/.claude/settings.json"
+    setup_feature_worktree
+
+    run "$NN"
+    [ "$status" -eq 0 ]
+    # Still launched: the removal is a side effect, not a short-circuit.
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
+    # The machine-local file goes; the shared one stays put.
+    [ ! -e "$REPO_DIR/.claude/settings.local.json" ]
+    [ -f "$REPO_DIR/.claude/settings.json" ]
+}
+
+@test "bin/nn announces the removal of the main checkout's settings.local.json" {
+    setup_git_repo
+    setup_upstream
+    mkdir -p "$REPO_DIR/.claude"
+    echo '{}' >"$REPO_DIR/.claude/settings.local.json"
+    setup_feature_worktree
+
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Removing $REPO_DIR/.claude/settings.local.json"* ]]
+}
+
+@test "bin/nn does not remove settings.local.json from the plain main checkout" {
+    # A plain main checkout (not a worktree) must keep its own approved
+    # permissions: the removal is scoped to worktree launches only.
+    setup_git_repo
+    mkdir -p "$REPO_DIR/.claude"
+    echo '{}' >"$REPO_DIR/.claude/settings.local.json"
+    cd "$REPO_DIR"
+
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f "$REPO_DIR/.claude/settings.local.json" ]
+}
+
+@test "bin/nn succeeds from a worktree when the main checkout has no .claude dir" {
+    # The [[ -f ]] guard must tolerate a main checkout with no settings at all.
+    setup_git_repo
+    setup_upstream
+    [ ! -d "$REPO_DIR/.claude" ]
+    setup_feature_worktree
+
+    run "$NN"
+    [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/nono-argv" ]
+}
+
 @test "bin/nn auto-detect skips oalders-docker for a bare Dockerfile" {
     # A Dockerfile alone is not a marker: a repo that only builds an image has
     # no compose/buildx workflow to fix, so the mixin would be noise. This is


### PR DESCRIPTION
Closes #1015

## Changes

`bin/add-worktree` deletes the main checkout's `.claude/settings.local.json`
before creating a worktree (#1014), but that cleanup is point-in-time: a later
Claude session in the main checkout recreates the file, and every existing
worktree warns again (anthropics/claude-code#77998) until the next
`add-worktree` run.

`bin/nn` is the per-launch entry point for worktree sessions, so this makes the
cleanup durable there:

- When launched **from a worktree**, `nn` now removes the main checkout's
  machine-local `.claude/settings.local.json` before launching claude, on every
  launch rather than only at worktree-creation time.
- Reuses the already-resolved `common_dir` and `project_root` (no new discovery
  logic). Main checkout root = `realpath "$common_dir/.."`; the removal fires
  only when that differs from `project_root`, so a plain main checkout keeps its
  own approved permissions.
- Mirrors `add-worktree` exactly: only the gitignored `settings.local.json` is
  removed (the shared `settings.json` is left in place), and the deletion is
  announced on stderr, not silent.

## Testing

- Added 4 bats cases in `test/nn.bats` (mirroring the #1014 tests): removal from
  a worktree with `settings.json` spared, the stderr announcement, the
  plain-main-checkout no-op, and tolerance of a main checkout with no `.claude`
  dir.
- `bats test/nn.bats test/add-worktree.bats` → all 65 pass.
- `shellcheck bin/nn` clean.
- Code review (general + security): the one flagged issue — `realpath -m` is
  GNU-only and would abort `nn` on macOS under `set -eu` — was fixed by using
  plain `realpath`, matching the file's existing calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 4.8
