### PR TITLE
ci: speed up the Build workflow apt install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,17 @@ jobs:
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/99-retries
           echo 'Acquire::http::Timeout "30";' | sudo tee -a /etc/apt/apt.conf.d/99-retries
 
+      - name: Make the apt archive cache dir writable
+        # /var/cache/apt/archives is root:root drwxr-xr-x; actions/cache
+        # restores as the unprivileged runner user, which can't write new
+        # .deb files into it unless we open it up first.
+        run: sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt archives
         uses: actions/cache@v4
         with:
           path: /var/cache/apt/archives/*.deb
-          key: apt-${{ runner.os }}-${{ hashFiles('installer/**/*.sh', 'configure/**/*.sh') }}
+          key: apt-${{ runner.os }}-${{ hashFiles('installer/linux.sh') }}
           restore-keys: |
             apt-${{ runner.os }}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Set up symlink to ~/dot-files
         run: cd && ln -s $GITHUB_WORKSPACE .
 
+      - name: Tolerate a slow/flaky apt mirror
+        run: |
+          echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/99-retries
+          echo 'Acquire::http::Timeout "30";' | sudo tee -a /etc/apt/apt.conf.d/99-retries
+
+      - name: Cache apt archives
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-${{ runner.os }}-${{ hashFiles('installer/**/*.sh', 'configure/**/*.sh') }}
+          restore-keys: |
+            apt-${{ runner.os }}-
+
       - name: Install tmux deps
         run: sudo apt install libevent-dev
 

--- a/installer/linux.sh
+++ b/installer/linux.sh
@@ -64,8 +64,9 @@ else
     # libgcr-ui-3-1, pinentry-gnome3, ...) that's only useful for an
     # interactive desktop session storing git credentials. CI never launches
     # the keyring daemon, so skip it there to avoid downloading packages
-    # nothing exercises.
-    if ! is var GITHUB_ACTIONS eq true; then
+    # nothing exercises. IS_GITHUB comes from bash_functions.sh (sourced
+    # above), the repo's existing "are we in CI" signal.
+    if [[ $IS_GITHUB == false ]]; then
         packages+=(gnome-keyring)
     fi
 

--- a/installer/linux.sh
+++ b/installer/linux.sh
@@ -37,27 +37,39 @@ if ! is there apt; then
 else
 
     debounce 12 h sudo apt-get update -q
-    sudo apt-get install -y -q --no-install-recommends --autoremove \
-        build-essential \
-        chafa \
-        cpanminus \
-        curl \
-        gnome-keyring \
-        jq \
-        libexpat1-dev \
-        libnet-ssleay-perl \
-        libsecret-tools \
-        locate \
-        luarocks \
-        pandoc \
-        pipx \
-        python3-pip \
-        python3-setuptools \
-        ripgrep \
-        shellcheck \
-        tig \
-        tree \
+
+    packages=(
+        build-essential
+        chafa
+        cpanminus
+        curl
+        jq
+        libexpat1-dev
+        libnet-ssleay-perl
+        libsecret-tools
+        locate
+        luarocks
+        pandoc
+        pipx
+        python3-pip
+        python3-setuptools
+        ripgrep
+        shellcheck
+        tig
+        tree
         trurl
+    )
+
+    # gnome-keyring pulls in a GTK4/GCR desktop stack (libgtk-4-1,
+    # libgcr-ui-3-1, pinentry-gnome3, ...) that's only useful for an
+    # interactive desktop session storing git credentials. CI never launches
+    # the keyring daemon, so skip it there to avoid downloading packages
+    # nothing exercises.
+    if ! is var GITHUB_ACTIONS eq true; then
+        packages+=(gnome-keyring)
+    fi
+
+    sudo apt-get install -y -q --no-install-recommends --autoremove "${packages[@]}"
 fi
 
 if ! is there go; then


### PR DESCRIPTION
The Build workflow has been timing out at its 15-minute limit during
./install.sh, apparently since 0d738c1f (unrelated to the apt install path
itself — the CI mirror got slower, notably a ~6.5 minute pandoc download
observed in a failed run log).

## Changes

- Cache /var/cache/apt/archives via actions/cache, keyed on installer/linux.sh
  (the only file that defines the package list), with a step beforehand to
  make the cache-restore-owned directory writable by the unprivileged runner
  user.
- Skip installing gnome-keriring in CI: it pulls in a GTK4/GCR desktop stack
  that nothing in CI exercises, using the existing IS_GITHUB signal from
  bash_functions.sh.
- Add apt retry/timeout tolerance (Acquire::Retries, Acquire::http::Timeout)
  for a slow or flaky mirror.

## Testing

- shfmt -d -s -i 4 installer/linux.sh: clean
- shellcheck installer/linux.sh: clean (only pre-existing informational SC1091)
- bash -n installer/linux.sh: OK
- YAML parse of .github/workflows/build.yml: OK
- Code review (general + security), two passes: first pass found the cache
  directory would silently fail to restore due to root-only write
  permissions, an inconsistent CI-detection signal, and an overly broad cache
  key; all three fixed and the re-review came back clean.
- Not independently runnable locally (no way to execute the GitHub Actions
  workflow outside CI); verification is file-level as above. The real test is
  the next CI run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Opus 4.8