### PR TITLE
merge-pr: self-heal wrong tracking config instead of prompting

### DIFF
--- a/bin/merge-pr
+++ b/bin/merge-pr
@@ -118,42 +118,41 @@ if [[ -z "$close_mode" ]]; then
             # Branch IS on origin; only tracking config is wrong. This is not a
             # missing push, and cannot arise for a MERGED PR (its remote branch
             # is gone), so handle it immediately rather than deferring.
+            #
+            # Self-heal rather than prompting: the branch is already pushed,
+            # the repair is exactly what the user would have to type back, and
+            # it changes nothing about the code being merged — only which ref
+            # `@{u}` names. Report what was done instead of asking permission.
             echo "merge-pr: branch '$branch' is on origin, but local tracking config" >&2
             echo "          is wrong, so '@{u}' does not resolve. The branch is" >&2
-            echo "          already pushed — this is a config issue, not a missing push." >&2
-            printf "merge-pr: repair with 'git branch --set-upstream-to=origin/%s' and continue? [y/N] " "$branch" >&2
-            # Default to bailing: empty input (just Enter), EOF, or a
-            # non-interactive stdin all leave tracking untouched.
-            read -r reply || reply=""
-            case "$reply" in
-                [Yy]*)
-                    # --set-upstream-to needs refs/remotes/origin/<branch> to
-                    # exist locally, and it may not: origin has the branch (we
-                    # just asked it), but this clone may never have fetched it,
-                    # or the ref may be stale relative to what origin holds.
-                    # Both make the repair fail ("the requested upstream branch
-                    # does not exist") or leave the unpushed-commit check below
-                    # comparing against an out-of-date ref. Fetch the one ref
-                    # explicitly first — a full `git fetch` is unnecessary and
-                    # slow, and the explicit refspec avoids depending on the
-                    # remote's configured fetch refspec.
-                    # The leading "+" matches the standard remote-tracking
-                    # refspec: a stale local ref that isn't a fast-forward of
-                    # origin's still gets updated rather than failing.
-                    if ! git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" >&2; then
-                        echo "merge-pr: could not fetch 'refs/heads/$branch' from origin — cannot repair tracking." >&2
-                        exit 1
-                    fi
-                    # The ref is now current — the count block must not re-fetch
-                    # the same refspec.
-                    refreshed_ref=1
-                    git branch --set-upstream-to="origin/$branch" >&2
-                    ;;
-                *)
-                    echo "merge-pr: aborted — fix tracking config and re-run." >&2
-                    exit 1
-                    ;;
-            esac
+            echo "          already pushed, so repairing tracking with" >&2
+            echo "          'git branch --set-upstream-to=origin/$branch' and continuing." >&2
+            # --set-upstream-to needs refs/remotes/origin/<branch> to exist
+            # locally, and it may not: origin has the branch (we just asked
+            # it), but this clone may never have fetched it, or the ref may be
+            # stale relative to what origin holds. Both make the repair fail
+            # ("the requested upstream branch does not exist") or leave the
+            # unpushed-commit check below comparing against an out-of-date ref.
+            # Fetch the one ref explicitly first — a full `git fetch` is
+            # unnecessary and slow, and the explicit refspec avoids depending
+            # on the remote's configured fetch refspec.
+            # The leading "+" matches the standard remote-tracking refspec: a
+            # stale local ref that isn't a fast-forward of origin's still gets
+            # updated rather than failing.
+            if ! git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" >&2; then
+                echo "merge-pr: could not fetch 'refs/heads/$branch' from origin — cannot repair tracking." >&2
+                exit 1
+            fi
+            # The ref is now current — the count block must not re-fetch the
+            # same refspec.
+            refreshed_ref=1
+            # Guarded rather than bare: a failed repair must not fall through
+            # to the unpushed-commit check with '@{u}' still unresolved, where
+            # `git rev-list` would abort under `set -e` with a worse message.
+            if ! git branch --set-upstream-to="origin/$branch" >&2; then
+                echo "merge-pr: could not set upstream to 'origin/$branch' — fix tracking config and re-run." >&2
+                exit 1
+            fi
         else
             # Genuinely unpushed. Defer instead of bailing — a MERGED PR needs
             # no push. `@{u}` is unresolved, so skip the unpushed-commit check.

--- a/test/merge-pr.bats
+++ b/test/merge-pr.bats
@@ -60,44 +60,24 @@ setup() {
     [[ "$output" == *"has no upstream"* ]]
 }
 
-# #935: when @{u} fails but the branch IS on origin (only the local
-# tracking config is wrong), don't misdiagnose it as "push first".
-@test "pre-flight: misconfigured tracking is not reported as 'push first'" {
+# #935: when @{u} fails but the branch IS on origin (only the local tracking
+# config is wrong), don't misdiagnose it as "push first" — and don't prompt.
+# The repair is self-healing: closed stdin stands in for a non-interactive run
+# (cron, a pipe), where the old prompt aborted. Reaching PR lookup (which the
+# gh stub fails) proves the pre-flight passed on the repaired tracking.
+@test "pre-flight: misconfigured tracking self-heals instead of saying 'push first'" {
     setup_git_repo
     setup_upstream
     break_tracking_config
+    stub_command gh 'exit 1'
     run "$MERGE_PR" </dev/null
     [ "$status" -eq 1 ]
     [[ "$output" != *"push first"* ]]
     [[ "$output" == *"is on origin"* ]]
     [[ "$output" == *"--set-upstream-to=origin/main"* ]]
-}
-
-# Declining the repair prompt (empty input / no) leaves tracking untouched.
-@test "pre-flight: declining the tracking-repair prompt aborts without changes" {
-    setup_git_repo
-    setup_upstream
-    break_tracking_config
-    run "$MERGE_PR" <<<"n"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"aborted"* ]]
-    run git config "branch.main.remote"
-    [[ "$output" == "$UPSTREAM_DIR" ]]
-}
-
-# Accepting the repair prompt rewrites tracking to origin and proceeds past
-# the upstream pre-flight (then fails later at PR lookup — far enough to
-# prove the repair worked).
-@test "pre-flight: accepting the tracking-repair prompt sets upstream to origin" {
-    setup_git_repo
-    setup_upstream
-    break_tracking_config
-    stub_command gh 'exit 1'
-    run "$MERGE_PR" <<<"y"
-    # Repair succeeded, so the upstream pre-flight passed and we reached
-    # PR lookup (which the gh stub fails).
-    [ "$status" -eq 1 ]
     [[ "$output" == *"no PR found"* ]]
+    [[ "$output" != *"[y/N]"* ]]
+    [[ "$output" != *"aborted"* ]]
     run git config "branch.main.remote"
     [[ "$output" == "origin" ]]
 }
@@ -115,7 +95,7 @@ setup() {
     git config --unset branch.feature.remote || true
     git config --unset branch.feature.merge || true
     stub_command gh 'exit 1'
-    run "$MERGE_PR" <<<"y"
+    run "$MERGE_PR" </dev/null
     # Reaching PR lookup (which the gh stub fails) proves the repair worked.
     [ "$status" -eq 1 ]
     [[ "$output" == *"no PR found"* ]]


### PR DESCRIPTION
## What

When `@{u}` doesn't resolve but the branch **is** on origin, only the local tracking config is wrong. `merge-pr` already detected this and offered `git branch --set-upstream-to=origin/<branch>` — but behind a `[y/N]` prompt that defaulted to aborting.

Now it just does the repair and reports it.

## Why

- The repair is exactly what the user would have to type back, and it changes nothing about the code being merged — only which ref `@{u}` names.
- The prompt defaulted to abort on EOF, so **any non-interactive run** (closed stdin, a pipe) bailed outright even though the fix was mechanical.

Failures in either step (the single-ref fetch, or the `--set-upstream-to`) still bail with the manual command. The `--set-upstream-to` call is now guarded — it was previously bare, so a failed repair would have fallen through to the unpushed-commit check with `@{u}` still unresolved and aborted under `set -e` with a worse message.

## Tests

The three prompt-path tests (misdiagnosis / decline / accept) collapse into one that runs with `</dev/null` and asserts the repair happened, no `[y/N]`, no abort, and `branch.main.remote == origin`. The no-local-tracking-ref test also runs with closed stdin now.

`precious lint` clean. Note: `test/merge-pr.bats` has 3 pre-existing failures on `main` (`pr state: refuses CLOSED state`, `refuses DRAFT state`, `--close on a MERGED PR refuses`) — confirmed failing on a clean tree, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)